### PR TITLE
feat: add Linux and Windows support to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ A React scaffold with clean architecture for learning to build with Claude Code.
 
 ## Prerequisites
 
-- A Mac
+- A Mac, Linux machine, or Windows PC
 - An internet connection
 - **[VS Code](https://code.visualstudio.com/)** — Free code editor. You'll use this to see what Claude Code is doing and to browse your project files. Download and install it before the workshop.
 - **[GitHub account](https://github.com/signup)** — Free. This is how you'll save your work, undo mistakes, and experiment safely. Think of it as version control for your code — unlimited undo, branches to try ideas without breaking what works, and a backup of everything you build. If you don't have an account, create one now. It takes 2 minutes.
+- **Windows users:** Run the install script from [Git Bash](https://git-scm.com/download/win) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 The install script handles everything else — including Claude Code itself.
 
@@ -23,8 +24,13 @@ cd investiture
 ./install.sh
 ```
 
-This installs Homebrew (if needed), Node.js (if needed), project dependencies,
-and creates a CLAUDE.md file that tells Claude Code about your project.
+The script detects your platform and installs the right dependencies:
+- **Mac:** Homebrew and Node.js via brew
+- **Linux/WSL:** Git and Node.js via your package manager (apt, dnf, pacman, zypper)
+- **Windows (Git Bash):** Node.js via winget or choco
+
+It also installs project dependencies and creates a CLAUDE.md file that tells
+Claude Code about your project.
 
 ---
 
@@ -44,9 +50,9 @@ To see the interactive examples: `npm run examples` (opens at :3001)
 
 When you ran `install.sh`, it:
 
-1. **Checked for command line tools** — Xcode CLT, which includes Git
-2. **Checked for Homebrew** — a Mac package manager that installs developer tools
-3. **Checked for Node.js** — the JavaScript runtime that runs your app
+1. **Detected your platform** — Mac, Linux, WSL, or Windows (Git Bash)
+2. **Ensured Git is available** — Xcode CLT on Mac, package manager on Linux, or checked for it on Windows
+3. **Ensured Node.js is available** — via Homebrew, your Linux package manager, or winget/choco on Windows
 4. **Installed dependencies** — React and Vite (a fast dev server)
 5. **Installed Claude Code** — the AI coding assistant (if not already installed)
 6. **Created CLAUDE.md** — a file that briefs Claude Code on your project structure and rules

--- a/install.sh
+++ b/install.sh
@@ -8,35 +8,171 @@ echo "  Investiture Setup"
 echo "  Getting your development environment ready..."
 echo ""
 
-# 1. Check for Xcode Command Line Tools (includes Git)
-if ! xcode-select -p &> /dev/null; then
-  echo "  Installing command line tools (includes Git)..."
-  echo "  A system dialog may appear — click Install and wait for it to finish."
-  xcode-select --install
-  echo ""
-  echo "  ⚠  After the install finishes, run ./install.sh again."
-  echo ""
-  exit 0
-else
-  echo "  Command line tools found (includes Git)"
+# Detect platform
+detect_platform() {
+  case "$(uname -s)" in
+    Darwin*)  echo "mac" ;;
+    Linux*)
+      if [ -f /proc/version ] && grep -qi microsoft /proc/version; then
+        echo "linux"  # WSL behaves like Linux for install purposes
+      else
+        echo "linux"
+      fi
+      ;;
+    MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+PLATFORM="$(detect_platform)"
+
+if [ "$PLATFORM" = "unknown" ]; then
+  echo "  Unsupported operating system: $(uname -s)"
+  echo "  This script supports macOS, Linux, and Windows (Git Bash or WSL)."
+  exit 1
 fi
 
-# 2. Check for Homebrew (skipped if already installed)
-if ! command -v brew &> /dev/null; then
-  echo "  Installing Homebrew (Mac package manager)..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  # Add to path for Apple Silicon Macs
-  if [ -f /opt/homebrew/bin/brew ]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
+echo "  Detected platform: $PLATFORM"
+
+# Detect Linux package manager
+detect_linux_pkg_manager() {
+  if command -v apt-get &> /dev/null; then
+    echo "apt"
+  elif command -v dnf &> /dev/null; then
+    echo "dnf"
+  elif command -v pacman &> /dev/null; then
+    echo "pacman"
+  elif command -v zypper &> /dev/null; then
+    echo "zypper"
+  else
+    echo "unknown"
   fi
-else
-  echo "  Homebrew found"
+}
+
+# 1. Ensure Git is available
+if [ "$PLATFORM" = "mac" ]; then
+  if ! xcode-select -p &> /dev/null; then
+    echo "  Installing command line tools (includes Git)..."
+    echo "  A system dialog may appear — click Install and wait for it to finish."
+    xcode-select --install
+    echo ""
+    echo "  After the install finishes, run ./install.sh again."
+    echo ""
+    exit 0
+  else
+    echo "  Command line tools found (includes Git)"
+  fi
+elif [ "$PLATFORM" = "linux" ]; then
+  if ! command -v git &> /dev/null; then
+    PKG_MANAGER="$(detect_linux_pkg_manager)"
+    echo "  Installing Git..."
+    case "$PKG_MANAGER" in
+      apt)    sudo apt-get update -qq && sudo apt-get install -y -qq git ;;
+      dnf)    sudo dnf install -y -q git ;;
+      pacman) sudo pacman -Sy --noconfirm git ;;
+      zypper) sudo zypper install -y git ;;
+      *)
+        echo "  Could not detect a supported package manager (apt, dnf, pacman, zypper)."
+        echo "  Please install Git manually and re-run this script."
+        exit 1
+        ;;
+    esac
+  else
+    echo "  Git found"
+  fi
+elif [ "$PLATFORM" = "windows" ]; then
+  if ! command -v git &> /dev/null; then
+    echo "  Git is not installed."
+    echo "  Download and install it from: https://git-scm.com/download/win"
+    echo "  Then re-run this script from Git Bash."
+    exit 1
+  else
+    echo "  Git found"
+  fi
 fi
 
-# 3. Check for Node.js
+# 2. Ensure a package manager / system dependencies
+if [ "$PLATFORM" = "mac" ]; then
+  if ! command -v brew &> /dev/null; then
+    echo "  Installing Homebrew (Mac package manager)..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    # Add to path for Apple Silicon Macs
+    if [ -f /opt/homebrew/bin/brew ]; then
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+    fi
+  else
+    echo "  Homebrew found"
+  fi
+elif [ "$PLATFORM" = "linux" ]; then
+  PKG_MANAGER="$(detect_linux_pkg_manager)"
+  if [ "$PKG_MANAGER" = "unknown" ]; then
+    echo "  Could not detect a supported package manager (apt, dnf, pacman, zypper)."
+    echo "  Please install Node.js manually and re-run this script."
+    exit 1
+  fi
+  echo "  Package manager found ($PKG_MANAGER)"
+elif [ "$PLATFORM" = "windows" ]; then
+  if command -v winget &> /dev/null; then
+    WIN_PKG="winget"
+    echo "  Package manager found (winget)"
+  elif command -v choco &> /dev/null; then
+    WIN_PKG="choco"
+    echo "  Package manager found (choco)"
+  else
+    WIN_PKG="none"
+  fi
+fi
+
+# 3. Ensure Node.js is available
 if ! command -v node &> /dev/null; then
   echo "  Installing Node.js..."
-  brew install node
+
+  if [ "$PLATFORM" = "mac" ]; then
+    brew install node
+
+  elif [ "$PLATFORM" = "linux" ]; then
+    PKG_MANAGER="$(detect_linux_pkg_manager)"
+    case "$PKG_MANAGER" in
+      apt)
+        # Use NodeSource for an up-to-date version instead of the distro default
+        echo "  Adding NodeSource repository for current Node.js..."
+        sudo apt-get update -qq && sudo apt-get install -y -qq ca-certificates curl gnupg
+        sudo mkdir -p /etc/apt/keyrings
+        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg 2>/dev/null
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+        sudo apt-get update -qq && sudo apt-get install -y -qq nodejs
+        ;;
+      dnf)
+        sudo dnf install -y -q nodejs npm
+        ;;
+      pacman)
+        sudo pacman -Sy --noconfirm nodejs npm
+        ;;
+      zypper)
+        sudo zypper install -y nodejs npm
+        ;;
+    esac
+
+  elif [ "$PLATFORM" = "windows" ]; then
+    if [ "$WIN_PKG" = "winget" ]; then
+      winget install --id OpenJS.NodeJS -e --accept-source-agreements --accept-package-agreements
+    elif [ "$WIN_PKG" = "choco" ]; then
+      choco install nodejs -y
+    else
+      echo "  Could not install Node.js automatically."
+      echo "  Download and install it from: https://nodejs.org"
+      echo "  Then re-run this script."
+      exit 1
+    fi
+  fi
+
+  # Verify node is now available (may need path refresh on Windows)
+  if ! command -v node &> /dev/null; then
+    echo ""
+    echo "  Node.js was installed but isn't available in this shell yet."
+    echo "  Close this terminal, open a new one, and re-run ./install.sh"
+    exit 0
+  fi
 else
   echo "  Node.js found ($(node --version))"
 fi
@@ -52,7 +188,7 @@ if ! command -v claude &> /dev/null; then
   if command -v claude &> /dev/null; then
     echo "  Claude Code installed"
   else
-    echo "  ⚠  Claude Code install may need a terminal restart."
+    echo "  Claude Code install may need a terminal restart."
     echo "  If 'claude' doesn't work, run: npm install -g @anthropic-ai/claude-code"
   fi
 else
@@ -146,7 +282,7 @@ fi
 # 7. Check for Git config
 echo ""
 if ! git config user.name &> /dev/null || ! git config user.email &> /dev/null; then
-  echo "  ⚠  Git is not configured with your name/email."
+  echo "  Git is not configured with your name/email."
   echo "  Run these two commands (use your info):"
   echo ""
   echo "    git config --global user.name \"Your Name\""


### PR DESCRIPTION
## Summary
- Detect platform (macOS, Linux, Windows/Git Bash, WSL) via `uname` and branch setup steps accordingly
- Linux: install Git and Node.js via apt/dnf/pacman/zypper, using NodeSource for apt-based distros to avoid stale Node versions
- Windows: support both Git Bash (winget/choco) and WSL (follows the Linux path), with manual install fallbacks
- Add post-install Node.js verification for shells that need a PATH refresh

## Test plan
- [ ] Verify macOS path still works (Xcode CLT, Homebrew, `brew install node`)
- [ ] Test on Ubuntu/Debian (apt + NodeSource)
- [ ] Test on Fedora (dnf)
- [ ] Test on Arch (pacman)
- [ ] Test on Windows Git Bash with winget
- [ ] Test on Windows Git Bash with choco
- [ ] Test on WSL (Ubuntu)
- [ ] Verify unsupported OS prints a clear error and exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)