### PR TITLE
feat: Investiture v1.4 — eight new skills

### DIFF
--- a/.claude/skills/invest-adr/SKILL.md
+++ b/.claude/skills/invest-adr/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: invest-adr
+description: "Generate a numbered Architecture Decision Record for a specific decision, using VECTOR.md constraints, ARCHITECTURE.md stack context, and existing ADRs to avoid contradictions. Turns 'should we use X or Y?' into a complete, stored ADR."
+argument-hint: "[decision description] [--status proposed|accepted|deprecated|superseded] [--dry-run]"
+---
+
+# Investiture Skill: Decision Record
+
+You are capturing a decision before it becomes invisible. Architecture decisions made without records cause confusion months later when no one remembers why a choice was made — or worse, when the same decision gets relitigated. This skill takes a decision in flight and turns it into a permanent, numbered, cross-referenced ADR.
+
+**This skill runs on demand.** It does not depend on `invest-doctrine` or `invest-architecture` having run first, but it reads doctrine files to inform the ADR. It writes to `/vector/decisions/`, which `invest-backfill` initializes. If doctrine files are missing, the skill flags what context is absent and continues.
+
+## Step 0: Get the Decision Description
+
+If a decision description was passed as an argument, use it directly.
+
+If no argument was provided, prompt the operator:
+
+```
+What decision are you capturing? Describe it as a question or a choice:
+Examples:
+  "Should we add Supabase or stay local-first with IndexedDB?"
+  "Use React Query vs. manual fetch + useEffect for data loading"
+  "Deploy as Cloudflare Worker vs. Netlify serverless function"
+```
+
+## Step 1: Read Doctrine
+
+Read the following files. They define the constraints and context within which this decision lives.
+
+1. **`VECTOR.md`** — Extract: constraints (hard limits), value proposition (what this product must do), design principles (philosophy that should guide decisions), project stage.
+2. **`ARCHITECTURE.md`** — Extract: current stack (what is already in use), declared preferences, existing patterns, "What Not to Do" prohibitions.
+3. **`/vector/decisions/`** — List all existing ADR files. Read their titles and decisions. You need this to:
+   - Number the new ADR correctly (next in sequence after the highest existing number)
+   - Identify prior decisions this new one must not contradict
+   - Find prior decisions this one supersedes or relates to
+
+If VECTOR.md or ARCHITECTURE.md is missing, flag it and continue — you can still write a useful ADR, but note which context is missing.
+
+If `/vector/decisions/` does not exist, create it. The new ADR will be the first: `ADR-001`.
+
+## Step 2: Determine the ADR Number and Slug
+
+**Numbering:** Find the highest existing ADR number in `/vector/decisions/`. The new ADR is that number + 1, zero-padded to three digits: `001`, `002`, `031`, `100`.
+
+If no ADRs exist, start at `ADR-001`.
+
+**Slug:** Derive from the decision description. Lowercase, hyphenated, 3-6 words:
+- "Should we add Supabase or stay local-first with IndexedDB?" → `supabase-vs-indexeddb`
+- "Use React Query vs. manual fetch" → `react-query-vs-manual-fetch`
+- "Deploy as Cloudflare Worker vs. Netlify" → `cloudflare-worker-vs-netlify`
+
+**Filename:** `ADR-[NNN]-[slug].md`
+
+## Step 3: Analyze the Decision
+
+Before writing the ADR, think through the decision using the doctrine context:
+
+**Options identification:** What are the real alternatives? There are almost always at least two, sometimes three. Name them clearly. "Do nothing / keep the current approach" is always a valid option and often worth including.
+
+**Constraint filtering:** Which options are ruled out by VECTOR.md constraints or ARCHITECTURE.md prohibitions? For example, if VECTOR.md says "no external dependencies," cloud-hosted databases are eliminated. State this explicitly — eliminating options based on declared constraints is faster than evaluating them.
+
+**Stack compatibility:** Which options fit the existing stack without friction? Which require new dependencies, new patterns, or new expertise?
+
+**Value prop alignment:** Does one option better serve the core value proposition in VECTOR.md? If yes, that's a meaningful signal, not just a technical preference.
+
+**Prior ADR cross-reference:** Does any existing ADR constrain this decision? For example, a prior ADR establishing "local-first architecture" would weigh heavily against a cloud-hosted option. If a prior ADR is directly relevant, reference it by number.
+
+## Step 4: Draft the ADR
+
+Write a complete ADR using this structure:
+
+```markdown
+# ADR-[NNN]: [Decision Title — present tense, descriptive]
+
+**Date:** [today's date]
+**Status:** [proposed | accepted | deprecated | superseded by ADR-NNN]
+**Deciders:** [OPERATOR: List who was involved in this decision, or remove this line]
+
+## Context
+
+[2-4 sentences. What is the situation that requires a decision? What problem are we solving? What constraints apply from VECTOR.md or ARCHITECTURE.md? What is the cost of not deciding?]
+
+## Decision Drivers
+
+[Bullet list of the factors that matter most for this decision. These come from VECTOR.md constraints, ARCHITECTURE.md preferences, and project stage. Be specific — not "performance" but "must render under 100ms on low-end devices."]
+
+- [Driver 1 — sourced from doctrine if possible]
+- [Driver 2]
+- [Driver 3]
+
+## Options Considered
+
+### Option A: [Name]
+
+[1-2 sentences describing this option.]
+
+**Pros:**
+- [Concrete advantage — specific to this project, not generic]
+- [Another advantage]
+
+**Cons:**
+- [Concrete disadvantage or risk]
+- [Another disadvantage]
+
+### Option B: [Name]
+
+[Same structure]
+
+### Option C: [Name, if applicable]
+
+[Same structure]
+
+## Decision
+
+**We will [chosen option].**
+
+[2-3 sentences explaining why this option was chosen. Reference the decision drivers that it best satisfies. If a constraint from VECTOR.md or a prior ADR was the deciding factor, say so explicitly.]
+
+## Consequences
+
+**Positive:**
+- [What gets better or easier]
+- [What new capability this enables]
+
+**Negative:**
+- [What this forecloses — options that are now off the table]
+- [Technical debt or tradeoffs this introduces]
+- [What will need to be revisited if circumstances change]
+
+**Neutral:**
+- [Side effects that aren't good or bad, just worth knowing]
+
+## Related Decisions
+
+[List any ADRs that this decision relates to, supersedes, or is constrained by. Format: `ADR-NNN: [Title]`. Or "None." if this is the first ADR.]
+```
+
+**On the `[OPERATOR: ...]` bracket in Deciders:** Leave it exactly as written. Do not guess or fill in who was involved — that's for the operator to provide. If you do not know who made the decision, leave the bracket.
+
+**Status field:**
+- `proposed` — Decision is being considered, not yet finalized. Default if no `--status` flag was passed.
+- `accepted` — Decision is final.
+- `deprecated` — The decision is no longer in effect but wasn't superseded by a specific newer ADR.
+- `superseded by ADR-NNN` — A newer decision replaced this one.
+
+If `--status` was passed as an argument, use that value.
+
+## Step 5: Present for Confirmation
+
+**Output the drafted ADR to the terminal in full.** Then ask:
+
+```
+ADR-[NNN]-[slug].md drafted above.
+Write to /vector/decisions/ADR-[NNN]-[slug].md? (yes/no)
+```
+
+**If `--dry-run` was passed:** Output the ADR to the terminal and stop. Do not write the file, do not ask for confirmation.
+
+## Step 6: Write the File
+
+On confirmation, write to `/vector/decisions/ADR-[NNN]-[slug].md`.
+
+Create `/vector/decisions/` if it does not exist.
+
+**Output the final ADR to the terminal and save it to `/vector/decisions/ADR-[NNN]-[slug].md`.** Each ADR is a new sequential file — do not overwrite existing ADRs.
+
+After writing, output:
+
+```
+ADR-[NNN] written to /vector/decisions/ADR-[NNN]-[slug].md
+
+[If this supersedes a prior ADR:]
+Note: You may want to update ADR-[prior NNN] to set its status to "superseded by ADR-[NNN]."
+```
+
+## Arguments
+
+- **No arguments:** Interactive — prompts for decision description, uses `--status proposed` by default
+- **`[decision description]`:** Uses the argument as the decision description, skips the prompt
+- **`--status [proposed|accepted|deprecated|superseded]`:** Sets the ADR status field
+- **`--dry-run`:** Drafts and displays the ADR without writing the file
+
+## Output
+
+`/vector/decisions/ADR-[NNN]-[slug].md`
+
+## When to Run
+
+- Before committing to a new dependency or external service
+- Before adopting a new architectural pattern that will propagate across the codebase
+- Before making a choice that is hard to reverse
+- When the same decision keeps coming up — record it so it stops being relitigated
+- After a significant pivot — record what changed and why
+
+## Principles
+
+- **One decision, one ADR.** Don't bundle multiple choices into a single record. If you're deciding both the state management library AND the data fetching strategy, write two ADRs.
+- **Constraints are filters, not opinions.** If VECTOR.md rules something out, say so clearly. You're not making a judgment call — you're applying declared doctrine.
+- **"Do nothing" is always an option.** Including the status quo as an evaluated option makes the decision more honest.
+- **Specificity over generality.** "Fast enough for our users" is not a decision driver. "Must render initial content under 200ms on a 3G connection" is.
+- **Consequences matter as much as the decision.** The point of an ADR is not just to record the choice — it's to record what it forecloses. Future contributors need to know what they're inheriting.

--- a/.claude/skills/invest-adr/SKILL.md
+++ b/.claude/skills/invest-adr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-adr
-description: "Generate a numbered Architecture Decision Record for a specific decision, using VECTOR.md constraints, ARCHITECTURE.md stack context, and existing ADRs to avoid contradictions. Turns 'should we use X or Y?' into a complete, stored ADR."
+description: "Generates a numbered Architecture Decision Record from a decision description, using VECTOR.md constraints, ARCHITECTURE.md stack context, and existing ADRs to avoid contradictions. Use when making an architectural or product decision that should be documented and stored."
 argument-hint: "[decision description] [--status proposed|accepted|deprecated|superseded] [--dry-run]"
 ---
 

--- a/.claude/skills/invest-brief/SKILL.md
+++ b/.claude/skills/invest-brief/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: invest-brief
+description: "Generate a design brief for a specific feature or flow from existing project research. Reads personas, JTBD, VECTOR.md principles and constraints, and quality gates to give a designer actionable direction grounded in real evidence — not assumptions about the audience."
+argument-hint: "[feature description] [--dry-run]"
+---
+
+# Investiture Skill: Design Brief
+
+You are turning research into direction. A designer sitting down to work on a feature needs to know who they're designing for, what job that person is trying to do, what principles should guide every decision, and what success looks like. This skill reads the project's accumulated research and doctrine and assembles that information into a brief a designer can act on immediately — without having to read through multiple files or ask someone.
+
+**This skill runs on demand, before design work begins.** It reads what has been learned (personas, JTBD, assumptions) and what has been declared (design principles, constraints, quality gates). The richer those sources are, the more specific the brief. If research is sparse, the brief will say so clearly — which is itself useful signal.
+
+## Step 0: Get the Feature or Flow Description
+
+**If a description was passed as an argument:** Use it directly.
+
+**If no argument was passed:** Prompt the operator:
+
+```
+What are you designing?
+Describe the feature, flow, or surface — what the user will do or experience.
+
+Examples:
+  "Onboarding flow for a first-time user who has never used the product"
+  "Settings panel for managing notification preferences"
+  "Empty state for a dashboard with no data yet"
+  "Export flow for saving a project as a file"
+```
+
+## Step 1: Read Research and Doctrine
+
+Read the following sources. Extract only what is relevant to the described feature or flow.
+
+**If `/vector/research/` does not exist:** Note it prominently and continue using VECTOR.md only: "Research directory not found. Run `/invest-backfill` to initialize the research structure. Brief will be based on VECTOR.md doctrine only — persona, JTBD, and assumption sections will be inferred or incomplete."
+
+1. **`VECTOR.md`** — Extract:
+   - **Target audience** — who the product is for. This defines who you're designing for.
+   - **Design principles** — the philosophy that should guide every design decision
+   - **Value proposition** — what the product delivers. The brief should reinforce this, not contradict it.
+   - **Constraints** — anything that limits what is possible (platform, performance, accessibility requirements, offline support)
+   - **Quality gates** — ship criteria that apply to this feature. These become the brief's success criteria.
+   - **Open questions** — anything the project is still uncertain about that is relevant to this feature
+
+2. **`/vector/research/personas/`** — Read all persona files. For each, extract:
+   - Who this person is (role, context, level of expertise)
+   - Their relevant goals and motivations
+   - Their known frustrations or pain points
+   - Behaviors relevant to this feature or flow
+
+   If no persona files exist, note it: "No personas documented yet — audience section will draw from VECTOR.md target audience only."
+
+3. **`/vector/research/jtbd/`** — Read all JTBD files. Identify:
+   - Jobs directly relevant to this feature or flow ("When I [situation], I want to [job], so I can [outcome]")
+   - Jobs that are adjacent — what the user was doing before they reached this feature, and what they need to do after
+
+   If no JTBD files exist, note it: "No JTBD documented yet — jobs section will be inferred from the feature description and VECTOR.md."
+
+4. **`/vector/research/assumptions/`** — Scan for assumptions relevant to this feature. Note:
+   - Validated assumptions that inform the design (confirmed beliefs about users that should shape decisions)
+   - Unvalidated assumptions that introduce risk (beliefs about users that are still untested — design decisions based on these are bets)
+   - Invalidated assumptions that should be avoided (things the team once believed but research disproved)
+
+5. **`/vector/decisions/`** — Scan ADR titles for any decisions directly relevant to this feature. If found, read them. Prior architectural or product decisions may constrain or inform the design.
+
+6. **`ARCHITECTURE.md`** — Extract only design-relevant information:
+   - UI/component layer: where components live, file naming conventions
+   - Token system: where design tokens are defined, how they're referenced
+   - Any styling constraints declared (CSS approach, component structure)
+
+## Step 2: Identify the Primary User
+
+From the personas and VECTOR.md audience, determine who is most likely to use this feature or flow. If multiple personas apply, rank them:
+
+- **Primary:** The user this design should be optimized for
+- **Secondary:** Users who will also use this feature but are not the primary audience
+
+State clearly: "This brief is optimized for [primary persona or audience description]."
+
+If no personas exist, derive the primary user from VECTOR.md's target audience. If that is also a placeholder, flag it prominently and continue — the brief will be less specific but still useful.
+
+## Step 3: Identify the Relevant Jobs
+
+From the JTBD files and feature description, identify:
+
+**The main job:** What is the user trying to accomplish when they encounter this feature? Write it in JTBD format:
+> "When [situation], I want to [job], so I can [outcome]."
+
+**The before state:** What was the user doing immediately before reaching this feature? What context are they arriving from?
+
+**The after state:** What does success look like for the user after they complete this flow? Where do they go next?
+
+If JTBD files are sparse or absent, infer from the feature description — but mark inferences clearly: "[inferred — no JTBD documented for this]"
+
+## Step 4: Surface Relevant Constraints and Risks
+
+**From VECTOR.md constraints:** List any hard limits that apply to this feature. These are non-negotiable.
+
+**From unvalidated assumptions:** List any assumptions the design will depend on that haven't been tested yet. These are risks — the design may need to change if the assumption turns out to be wrong.
+
+**From invalidated assumptions:** List any things the team previously believed about users that turned out to be wrong, if relevant. These are traps to avoid repeating.
+
+**From prior ADRs:** Note any architectural decisions that constrain the design options.
+
+## Step 5: Write the Design Brief
+
+Assemble everything into a brief:
+
+```markdown
+# Design Brief: [Feature or Flow Name]
+
+**Date:** [today's date]
+**Designing for:** [primary persona name or audience description]
+**Feature / Flow:** [one sentence — what the user does]
+
+---
+
+## Who You're Designing For
+
+**Primary:** [persona name or description]
+[3-5 sentences. Who is this person? What do they care about? What is their relevant context, expertise level, and goal? What frustrates them about the current state?]
+
+**Secondary (if applicable):** [persona name or description]
+[2-3 sentences.]
+
+---
+
+## The Job
+
+> "When [situation], I want to [job], so I can [outcome]."
+
+**Before this flow:** [What the user was doing. What context they're arriving from. What state they're in — rushed, focused, confused, exploratory?]
+
+**After this flow:** [What success looks like for the user. Where they go next. What they now have or can do that they couldn't before.]
+
+---
+
+## Design Principles That Apply Here
+
+[From VECTOR.md design principles — select the 2-4 most relevant to this specific feature. For each, write one sentence on how it applies here specifically.]
+
+- **[Principle name]:** [How it applies to this feature]
+- **[Principle name]:** [How it applies to this feature]
+
+---
+
+## Constraints
+
+[Hard limits. These are not preferences — they cannot be violated.]
+
+- [Constraint from VECTOR.md, ARCHITECTURE.md, or prior ADR]
+- [Constraint]
+
+---
+
+## Success Criteria
+
+[What does "done" look like? Draw from VECTOR.md quality gates and the after-state above.]
+
+- [Specific, testable criterion]
+- [Another criterion]
+
+---
+
+## What We Know (Evidence)
+
+[Validated assumptions or research findings that should inform design decisions. Each item: the finding + source.]
+
+- "[Finding]" — [source: persona file, interview summary, validated assumption]
+- "[Finding]" — [source]
+
+---
+
+## What We Don't Know Yet (Risks)
+
+[Unvalidated assumptions this design will depend on. If these turn out to be wrong, the design may need to change.]
+
+- [Assumption] — [what would need to change if this is wrong]
+- [Assumption]
+
+[If no relevant unvalidated assumptions: "No unvalidated assumptions flagged for this feature."]
+
+---
+
+## Where to Look
+
+- Personas: /vector/research/personas/
+- JTBD: /vector/research/jtbd/
+- Full design principles: VECTOR.md
+- Technical constraints: ARCHITECTURE.md
+- Prior decisions: /vector/decisions/
+```
+
+## Step 6: Output
+
+**Print the brief to the terminal AND save it to `/vector/briefs/[feature-slug]-[date].md`.**
+
+Use a slug derived from the feature description: lowercase, hyphenated, 3-6 words.
+
+Create the `/vector/briefs/` directory if it does not exist.
+
+Do not overwrite existing briefs for the same slug and date — if the file exists, append `-2`, `-3`, etc. Briefs are point-in-time documents; each represents the research state at the time it was generated.
+
+**If `--dry-run` was passed:** Print the brief to the terminal only. Do not write the file.
+
+After writing, output:
+
+```
+Design brief written to /vector/briefs/[feature-slug]-[date].md
+
+Research used: [N] persona(s), [N] JTBD file(s), [N] relevant assumption(s)
+[If any source was missing:] Note: [source] not found — [section] is inferred or incomplete.
+
+Run /invest-interview to generate a discussion guide for validating the open risks above.
+```
+
+## Arguments
+
+- **No arguments:** Interactive — prompts for feature or flow description
+- **`[feature description]`:** Uses the argument directly, skips the prompt
+- **`--dry-run`:** Generates and displays the brief without writing the file
+
+## Output
+
+`/vector/briefs/[feature-slug]-[date].md`
+
+## When to Run
+
+- Before starting design work on a feature or flow
+- When onboarding a designer to the project — use with `/invest-handoff --role designer`
+- When a feature has been in development for a while and the original design intent has drifted — regenerate the brief to check what it was based on
+- After `/invest-synthesize` updates personas or JTBD — regenerate briefs for in-progress features to see if direction has changed
+
+## Principles
+
+- **Research before opinions.** The brief draws from documented evidence — personas, validated assumptions, JTBD. Where research doesn't exist, it says so. A gap in the brief is a signal to do more research, not a prompt to fill it with guesses.
+- **Specific over general.** "Design for users" is not a brief. "Design for a solo developer who has shipped two projects and is now managing a contributor for the first time" is a brief. Specificity is the whole point.
+- **Constraints are design material.** Every limit in the brief — offline support required, no external dependencies, must load under 200ms — is something to design within, not around. Surface them prominently.
+- **Risks are honest.** Unvalidated assumptions that a design depends on are risks. Naming them in the brief means the designer knows what decisions are bets and can flag them before shipping.
+- **The brief is a snapshot.** It reflects what the project knows today. If research changes, regenerate it. A stale brief is worse than no brief — it gives false confidence.

--- a/.claude/skills/invest-brief/SKILL.md
+++ b/.claude/skills/invest-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-brief
-description: "Generate a design brief for a specific feature or flow from existing project research. Reads personas, JTBD, VECTOR.md principles and constraints, and quality gates to give a designer actionable direction grounded in real evidence — not assumptions about the audience."
+description: "Generates a design brief for a specific feature or flow from existing project research. Reads personas, JTBD, VECTOR.md principles and constraints, and quality gates to give a designer actionable direction grounded in real evidence. Use before design work begins on a feature or flow."
 argument-hint: "[feature description] [--dry-run]"
 ---
 

--- a/.claude/skills/invest-changelog/SKILL.md
+++ b/.claude/skills/invest-changelog/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: invest-changelog
+description: "Read git log since the last tag and VECTOR.md value prop, group commits by user-facing theme, filter out internal noise, and write a plain-language changelog keyed to what users can actually do now. Turns git history into release communication."
+argument-hint: "[--since tag|commit] [--version x.y.z] [--dry-run]"
+---
+
+# Investiture Skill: Write Changelog
+
+You are translating engineering history into user communication. `git log` tells you what changed in the code. VECTOR.md tells you what matters to the people using it. This skill bridges the two — reading both, filtering ruthlessly, and writing in plain language that describes outcomes, not implementation.
+
+**This skill runs at release time.** It depends on a readable git history and a filled-in VECTOR.md. The richer the VECTOR.md value proposition and audience description, the more accurately the changelog can frame changes in terms users care about.
+
+## Step 1: Read Doctrine
+
+Read the following before touching git:
+
+1. **`VECTOR.md`** — Extract:
+   - **Value proposition** — the core outcome the product delivers. This is the lens for deciding what is "user-facing."
+   - **Target audience** — who reads this changelog. A changelog for developers reads differently than one for end users.
+   - **Design principles** — informs voice and framing
+   - **Project stage** — a discovery-stage project may not have formal releases; note this if VECTOR.md stage is "discovery"
+
+If VECTOR.md is missing or its value prop is a template placeholder, flag it: "VECTOR.md value prop is not filled in — changelog will use plain commit grouping without audience framing." Continue.
+
+## Step 2: Determine the Commit Range
+
+**If `--since [tag|commit]` was passed:** Use that as the start of the range. End at HEAD.
+
+**If no `--since` argument was passed:** Find the most recent git tag.
+- Run: `git tag --sort=-creatordate | head -1`
+- If a tag exists, use it as the range start. End at HEAD.
+- If no tags exist, use all commits: run `git log --oneline` without a range restriction.
+
+Run `git log [range]..HEAD --oneline` (or `git log --oneline` if no range) to confirm the scope and show the commit count. Report to the terminal: "Reading [N] commits since [tag/commit]."
+
+**If the range is empty (no commits since last tag):** Report: "No commits found since [tag]. Nothing to changelog." Stop.
+
+## Step 3: Read the Full Commit Log
+
+Run: `git log [range]..HEAD --format="%H %s" --no-merges`
+
+For each commit, extract:
+- **Hash** (first 7 characters)
+- **Subject line** (the commit message summary)
+- **Body** if present: `git show [hash] --format="%b" --no-patch`
+
+Build a working list of all commits. You will filter and group them in Steps 4 and 5.
+
+## Step 4: Filter — Drop Internal Noise
+
+Remove commits from the working list that are not user-visible. A user cannot see these changes — they are internal to how the project is built or maintained.
+
+**Drop unconditionally:**
+- Dependency bumps with no behavior change: `bump`, `upgrade`, `update [package]`, version number changes in lock files
+- Build system changes: `ci:`, `build:`, `chore:`, changes to `.github/`, `Makefile`, `Dockerfile`, `package.json` scripts only
+- Documentation changes that are not user-facing: `docs:`, README updates, inline comment changes, type annotation-only changes
+- Formatting and linting: `style:`, `lint:`, `fmt:`, whitespace-only commits
+- Internal refactors with no behavior change: `refactor:` where the subject says "no behavior change" or "internal"
+- Test-only changes: `test:`, `spec:`, changes to `*.test.*`, `*.spec.*`, `__tests__/`
+
+**Keep these even if they look internal:**
+- Dependency bumps that fix a user-visible bug (e.g., "bump X to fix Y crash" — the crash fix is user-facing)
+- Refactors that change performance users can observe
+- Documentation changes that are part of the product (help text, UI copy, onboarding content)
+
+**Ambiguous commits:** If the subject line is unclear, check the commit body for context. If still ambiguous, keep it — it's better to include something borderline than to drop a real user change.
+
+After filtering, report: "Kept [N] of [total] commits as user-facing."
+
+## Step 5: Group by User-Facing Theme
+
+Do not group by file, layer, or conventional commit prefix. Group by what changed for the user.
+
+**Canonical groups (use these if they fit; not all will apply to every release):**
+
+| Group | What belongs here |
+|-------|-------------------|
+| **New** | Net-new capabilities the user did not have before |
+| **Improved** | Existing features that work better, faster, or more reliably |
+| **Fixed** | Bugs that caused incorrect behavior, crashes, or data problems |
+| **Changed** | Behavior that is intentionally different in a way users will notice |
+| **Removed** | Features or options that no longer exist |
+
+**How to assign:**
+- Read each commit subject and body
+- Ask: "What can a user do now that they couldn't before?" (→ New) or "What was broken that works now?" (→ Fixed)
+- If a commit could fit two groups, prefer the more prominent user impact
+- If a commit genuinely doesn't fit any group after filtering, drop it
+
+**Write each item in plain language.** Not the commit subject — rewrite it in terms of outcome:
+- `fix: prevent null ref in AgentProfile.save()` → "Fixed a crash when saving an agent profile with no backend selected"
+- `feat: add json export to agent profile` → "Added JSON export for agent profiles"
+- `perf: cache voice list response in memory` → "Voice list now loads instantly after the first fetch"
+
+Keep each item to one sentence. Lead with the outcome, not the mechanism.
+
+## Step 6: Determine the Version Header
+
+**If `--version [x.y.z]` was passed:** Use that version.
+
+**If no version was passed:**
+- Check the most recent git tag for a semver version number
+- If found, suggest bumping it: "Last tag was v1.3.0. Suggest `--version 1.4.0` for this release."
+- If no semver tag exists, use the date: `[YYYY-MM-DD]`
+
+## Step 7: Write the Changelog Entry
+
+Format:
+
+```markdown
+## [version] — [date]
+
+### New
+- [item]
+- [item]
+
+### Improved
+- [item]
+
+### Fixed
+- [item]
+
+### Changed
+- [item]
+
+### Removed
+- [item]
+```
+
+**Rules:**
+- Omit any group with no items. Do not print empty sections.
+- If only one group has items, no header needed for that group — just list the items under the version heading.
+- Write for the target audience in VECTOR.md. If the audience is developers, technical specificity is fine. If the audience is end users, avoid implementation details entirely.
+- Each item is one sentence. Start with a verb: "Added", "Fixed", "Removed", "Improved".
+- Do not include commit hashes, PR numbers, or author names in the changelog entry itself.
+
+## Step 8: Output
+
+**Print the changelog entry to the terminal AND append it to `/vector/changelog/[version].md`.**
+
+Create the `/vector/changelog/` directory if it does not exist.
+
+Also check for a `CHANGELOG.md` at the project root:
+- If it exists, prepend the new entry at the top (below the `# Changelog` heading if present)
+- If it does not exist, create it with the new entry
+
+Overwrite `/vector/changelog/[version].md` if it already exists for this version — the current content is what matters.
+
+**If `--dry-run` was passed:** Print the entry to the terminal only. Do not write any files.
+
+After writing, output:
+
+```
+Changelog entry written to /vector/changelog/[version].md
+[If CHANGELOG.md was updated:] CHANGELOG.md updated.
+
+[N] commits in range. [N] kept as user-facing. [N] dropped as internal.
+```
+
+## Arguments
+
+- **No arguments:** Since last git tag, version from last tag or date
+- **`--since [tag|commit]`:** Explicit range start
+- **`--version [x.y.z]`:** Set the version header for this entry
+- **`--dry-run`:** Preview the entry without writing files
+
+## Output
+
+- `/vector/changelog/[version].md`
+- `CHANGELOG.md` (prepended if exists, created if not)
+
+## When to Run
+
+- At release time, before publishing release notes or updating a public changelog
+- After a sprint, to communicate what shipped to stakeholders
+- Before tagging a release — use `--dry-run` to preview what the release notes will say
+
+## Principles
+
+- **Value prop is the filter.** If VECTOR.md says the product's value is "instant, portable agent voices," a CSS refactor is not in the changelog. A new voice backend is.
+- **Outcomes, not mechanisms.** "Fixed null reference in AgentProfile" is a mechanism. "Fixed a crash when saving an agent profile with no backend selected" is an outcome. Rewrite for the latter.
+- **Omit empty groups.** A changelog with six headers and one item each is noise. A changelog with two headers and five meaningful items is signal.
+- **git log is evidence, not the changelog.** Commit messages are for engineers. The changelog is for users. They are different documents with different audiences. Translate, don't copy.
+- **Drop noise ruthlessly.** A changelog that includes every internal refactor trains users to stop reading it. The value of a changelog is in what it omits as much as what it includes.

--- a/.claude/skills/invest-changelog/SKILL.md
+++ b/.claude/skills/invest-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-changelog
-description: "Read git log since the last tag and VECTOR.md value prop, group commits by user-facing theme, filter out internal noise, and write a plain-language changelog keyed to what users can actually do now. Turns git history into release communication."
+description: "Reads git log since the last tag and VECTOR.md value prop, groups commits by user-facing theme, filters internal noise, and writes a plain-language changelog keyed to what users can now do. Use at release time or when updating a public changelog."
 argument-hint: "[--since tag|commit] [--version x.y.z] [--dry-run]"
 ---
 

--- a/.claude/skills/invest-crew/SKILL.md
+++ b/.claude/skills/invest-crew/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-crew
-description: "Decompose a feature into scoped agent tasks before a multi-agent sprint. Reads ARCHITECTURE.md layer ownership, CLAUDE.md agent model, and VECTOR.md constraints to generate a structured task manifest with branch names, commit prefixes, and explicit scope boundaries."
+description: "Decomposes a feature into scoped agent tasks before a multi-agent sprint. Reads ARCHITECTURE.md layer ownership, CLAUDE.md agent model, and VECTOR.md constraints to generate a structured task manifest with branch names, commit prefixes, and explicit scope boundaries. Use before starting multi-agent feature work."
 argument-hint: "[feature description] [--dry-run] [--format flat]"
 ---
 

--- a/.claude/skills/invest-crew/SKILL.md
+++ b/.claude/skills/invest-crew/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: invest-crew
+description: "Decompose a feature into scoped agent tasks before a multi-agent sprint. Reads ARCHITECTURE.md layer ownership, CLAUDE.md agent model, and VECTOR.md constraints to generate a structured task manifest with branch names, commit prefixes, and explicit scope boundaries."
+argument-hint: "[feature description] [--dry-run] [--format flat]"
+---
+
+# Investiture Skill: Crew Manifest
+
+You are doing pre-flight. Before a multi-agent sprint begins, someone has to break the work into pieces — deciding which layer owns what, which agent touches which file, and where each task stops. Without this, agents collide, scope bleeds, and the same file gets edited twice. This skill generates that decomposition before the first branch is cut.
+
+**This skill runs before multi-agent execution.** Runtime fleet management — sessions, dispatch, relay chains — is a separate concern. This skill handles pre-flight: what work exists, who owns it, and what each task must not touch. Run this first, then use the manifest to brief and dispatch your agents.
+
+**Depends on doctrine.** Run `/invest-doctrine` before running this if you're not sure the doctrine is current. This skill reads ARCHITECTURE.md layer ownership to assign tasks — if that file is stale, the manifest will be wrong.
+
+## Step 0: Get the Feature Description
+
+**If a feature description was passed as an argument:** Use it directly.
+
+**If no argument was passed:** Prompt the operator:
+
+```
+What feature are you decomposing?
+Describe it in plain terms — what the user will be able to do when it ships.
+
+Example: "Allow users to export an agent profile as a portable JSON file and import it on another device"
+```
+
+## Step 1: Read Doctrine
+
+Read all three doctrine files. You need them for different parts of the manifest:
+
+1. **`ARCHITECTURE.md`** — Extract:
+   - Layer table: every layer name, its directory, and its boundary rule
+   - Import direction: which layers can call which
+   - Naming conventions: file naming rules per layer
+   - Stack: what technologies each layer uses
+   - "What Not to Do" prohibitions
+
+2. **`CLAUDE.md`** — Extract:
+   - Agent model (if defined): are there named agents with assigned responsibilities?
+   - Commit format: prefix conventions (`feat:`, `fix:`, layer-specific prefixes)
+   - Branch naming: declared convention if any
+   - Any task decomposition guidance the operator has written
+
+3. **`VECTOR.md`** — Extract:
+   - Constraints: what the feature must not violate (no external dependencies, must work offline, etc.)
+   - Design principles: what the feature must honor
+   - Quality gates: ship criteria that apply to this feature
+
+If any doctrine file is missing, flag it and continue with reduced context. Note which layer assignments or conventions you couldn't verify.
+
+## Step 2: Decompose the Feature
+
+Break the feature into atomic tasks. An atomic task is one that:
+- Can be completed by a single agent without requiring changes from another agent first
+- Touches a single layer (or at most two adjacent layers that must change together)
+- Has a clear, testable done state
+- Can be described in one sentence
+
+**Decomposition approach:**
+
+1. **Identify the user-facing change** — what does the user see or do differently? This is typically a UI layer task.
+2. **Trace the data path** — what data does this feature create, read, update, or delete? Trace from UI → services → domain → storage/API. Each hop that requires new code is a task candidate.
+3. **Identify cross-cutting concerns** — does this feature require new types, schemas, or shared utilities? Those are separate tasks that other tasks may depend on.
+4. **Check for agent-assigned layers** — if CLAUDE.md defines named agents with layer ownership, assign each task to the appropriate agent.
+
+For each task, produce:
+
+| Field | Content |
+|-------|---------|
+| **Task ID** | Short identifier: `T1`, `T2`, `T3` |
+| **Name** | One sentence: what this task accomplishes |
+| **Layer** | The ARCHITECTURE.md layer this task lives in |
+| **Owner** | Agent name (from CLAUDE.md) or "unassigned" if no agent model is defined |
+| **Branch** | Branch name following declared convention, e.g., `feat/export-agent-profile-domain` |
+| **Commit prefix** | Conventional commit prefix for this layer's work |
+| **Inputs** | What this task needs from other tasks before it can start (dependencies) |
+| **Outputs** | What this task produces that other tasks depend on |
+| **Scope boundary** | Explicit statement of what this task does NOT touch |
+
+## Step 3: Check for Constraint Violations
+
+Before finalizing the manifest, check each task against:
+
+- **VECTOR.md constraints** — does any task introduce an external dependency the project prohibits? Does any task require network access in a context that must work offline?
+- **ARCHITECTURE.md prohibitions** — does any task violate the "What Not to Do" rules? (data fetching in UI layer, hardcoded values outside token files, etc.)
+- **Import direction** — does the task's layer assignment respect the declared import direction? A task in the domain layer must not import from the UI layer.
+
+Flag any violations before proceeding. A task that violates doctrine should not be in the manifest — it should be redesigned.
+
+## Step 4: Determine Task Order
+
+Produce a dependency graph. Some tasks must complete before others can start; others can run in parallel.
+
+Format:
+
+```
+Parallel (can start immediately):
+  T1, T3
+
+Sequential dependencies:
+  T2 requires: T1 (needs exported type from domain layer)
+  T4 requires: T2, T3 (UI task, needs both service and domain complete)
+```
+
+Identify the critical path — the longest sequential chain. That chain determines the minimum sprint length.
+
+## Step 5: Write the Manifest
+
+**Output the manifest to the terminal AND save it to `/vector/missions/[feature-slug].md`.**
+
+Create the `/vector/missions/` directory if it does not exist.
+
+Use a slug derived from the feature description: lowercase, hyphenated, 3-6 words.
+
+Manifest format:
+
+```markdown
+# Mission: [Feature Name]
+
+**Feature:** [one-sentence description of what the user can do when this ships]
+**Date:** [today's date]
+**Doctrine source:** ARCHITECTURE.md, CLAUDE.md, VECTOR.md
+
+## Constraint Check
+
+[List any constraints from VECTOR.md that apply to this feature, or "No constraints flagged."]
+[List any doctrine violations found and how they were resolved, or "No violations found."]
+
+## Tasks
+
+### T1: [Task name]
+**Layer:** [layer name] (`[directory path]`)
+**Owner:** [agent name or "unassigned"]
+**Branch:** `[branch-name]`
+**Commit prefix:** `[prefix]:`
+**Inputs:** [what this task needs, or "None — can start immediately"]
+**Outputs:** [what this task produces for downstream tasks]
+**Scope boundary:** This task does NOT touch [explicit list of what's out of scope].
+
+[Repeat for each task]
+
+## Execution Order
+
+**Parallel (start immediately):** T1, T3
+**After T1:** T2
+**After T2 + T3:** T4
+
+**Critical path:** T1 → T2 → T4 ([N] sequential tasks)
+
+## Done State
+
+This feature is complete when:
+- [Specific, testable criterion drawn from VECTOR.md quality gates or the feature description]
+- [Another criterion]
+- All tasks merged to [main branch name]
+```
+
+**If `--dry-run` was passed:** Output the manifest to the terminal only. Do not write the file.
+
+**If `--format flat` was passed:** Also output a flat task list after the standard manifest, one line per task, suitable for piping to external tools or pasting into other systems:
+
+```
+## Flat Task List
+
+[task-id] [branch] "[task name]"
+[task-id] [branch] "[task name]"
+[...]
+```
+
+After writing, output:
+
+```
+Mission manifest written to /vector/missions/[feature-slug].md
+
+[N] tasks. Critical path: [N] sequential tasks.
+[If agents are assigned:] [N] agents involved.
+[If no agent model defined:] No agent model found in CLAUDE.md — tasks marked "unassigned."
+```
+
+## Arguments
+
+- **No arguments:** Interactive — prompts for feature description
+- **`[feature description]`:** Uses the argument directly, skips the prompt
+- **`--dry-run`:** Generates and displays the manifest without writing the file
+- **`--format flat`:** Appends a flat one-line-per-task list after the standard manifest for piping to external tools
+
+## Output
+
+`/vector/missions/[feature-slug].md`
+
+## When to Run
+
+- Before starting a multi-agent sprint
+- After `/invest-doctrine` confirms doctrine is current — the manifest is only as good as the doctrine it reads
+- When a feature is large enough to require more than one agent or more than one layer change
+
+## Principles
+
+- **Doctrine before decomposition.** If ARCHITECTURE.md doesn't declare layer ownership clearly, the manifest can't assign tasks correctly. Run `/invest-doctrine` first if you're not sure the doctrine is sound.
+- **Atomic tasks only.** A task that touches three layers is three tasks. A task that requires another task to finish halfway through is a design error. Decompose until each task is independently completable.
+- **Scope boundaries are as important as task descriptions.** An agent that knows what it does is useful. An agent that also knows what it must not do is safe. Every task gets an explicit scope boundary.
+- **Dependency mapping prevents collisions.** Two agents editing the same file at the same time is not a scheduling problem — it's a decomposition failure. If two tasks share a file, one of them is wrong.
+- **This skill is pre-flight, not planning.** It does not decide what to build — that decision comes from product research and VECTOR.md. It does not manage runtime sessions or agent dispatch. It bridges the gap: from "we know what to build" to "agents know what to do."

--- a/.claude/skills/invest-handoff/SKILL.md
+++ b/.claude/skills/invest-handoff/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: invest-handoff
+description: "Generate a single condensed onboarding document for a human collaborator or cold agent session, tailored to a specific role. Reads VECTOR.md, CLAUDE.md, ARCHITECTURE.md, and current /vector/ state to tell someone exactly what they need to know to contribute without reading everything."
+argument-hint: "[--role engineer|designer|agent|client] [--dry-run]"
+---
+
+# Investiture Skill: Generate Handoff
+
+You are writing the document that saves someone an hour of reading. VECTOR.md, CLAUDE.md, and ARCHITECTURE.md are comprehensive — but a contractor who needs to ship a feature this week, or an agent starting a cold session, does not need all of it. They need the right 20%. This skill reads the full doctrine and distills it into a role-specific brief that tells someone what this project is, what layer to touch, what not to do, and where to find answers.
+
+**This skill runs on demand.** It does not depend on other skills having run first, but it reads all three doctrine files. The richer the doctrine, the more useful the handoff. If doctrine is sparse, the handoff will be sparse — run `/invest-backfill` or fill in doctrine files first.
+
+## Step 0: Determine the Role
+
+**If `--role [role]` was passed:** Use that role. Valid values: `engineer`, `designer`, `agent`, `client`.
+
+**If no role was passed:** Generate a generic handoff suitable for any contributor. Skip role-specific sections.
+
+Role definitions:
+- **engineer** — A developer who will write or review code. Needs layer map, conventions, what not to do, and where things live. Less context on product vision.
+- **designer** — A designer who will work on UI, UX, or visual decisions. Needs design principles, token system, component structure, and product goals. Less context on technical layers.
+- **agent** — A Claude Code session starting cold. Needs a complete operational brief: reading order, what to do, what not to do, current status, and where to find everything.
+- **client** — A stakeholder who needs project context without implementation detail. Needs product goals, current stage, what has been built, and what's in progress. No technical depth.
+- **generic** — No role passed. Covers all bases at a moderate depth suitable for any contributor.
+
+## Step 1: Read Doctrine
+
+Read all three doctrine files:
+
+1. **`VECTOR.md`** — Extract: project name, problem statement, target audience, value proposition, current project stage, design principles, key constraints, quality gates, open questions, key assumptions and their status.
+2. **`CLAUDE.md`** — Extract: what the agent or contributor needs to know before touching code, stack summary, key context (non-obvious decisions), what not to do, commit format, standup format.
+3. **`ARCHITECTURE.md`** — Extract: layer table (names, locations, rules), import direction, naming conventions, stack, project structure tree, "What Not to Do."
+
+Also read the current `/vector/` state:
+4. **`/vector/audits/`** — List recent audit files. Read the most recent `invest-doctrine.md` and `invest-architecture.md` if they exist. Extract: current doctrine health, open violations, recent findings.
+5. **`/vector/decisions/`** — List ADR files. Note the count and read the titles. Recent ADRs signal active architectural decisions the contributor should know about.
+6. **`/vector/missions/`** — If this directory exists, list mission manifest files and note any active missions — this signals an in-progress sprint. If it does not exist, skip this section silently.
+
+If any doctrine file is missing, note it prominently in the handoff: "VECTOR.md not found — project identity section is incomplete."
+
+## Step 2: Write the Role-Specific Handoff
+
+Use the appropriate template for the role.
+
+---
+
+### For `--role engineer`
+
+```markdown
+# [Project Name] — Engineer Handoff
+**Date:** [today's date]
+
+## What This Is
+[2-3 sentences. Problem + solution + one distinguishing fact.]
+
+## Stack
+[Abbreviated stack table from CLAUDE.md — framework, styling, state, backend, deployment]
+
+## Layer Map
+[Condensed layer table: layer name, directory, one-sentence rule]
+
+## Import Direction
+[One-line summary: "UI → Services → Domain → [storage/API]. No reverse imports."]
+
+## Naming Conventions
+[2-3 most important conventions from ARCHITECTURE.md]
+
+## Do Not
+[The 3-5 most important prohibitions from ARCHITECTURE.md "What Not to Do" + CLAUDE.md]
+
+## Current Status
+[Project stage from VECTOR.md. Recent audit health if available. Any active missions from /vector/missions/.]
+
+## Where to Find Things
+- Doctrine: VECTOR.md → CLAUDE.md → ARCHITECTURE.md
+- Research: /vector/research/
+- Decisions: /vector/decisions/ ([N] ADRs)
+- Audits: /vector/audits/
+```
+
+---
+
+### For `--role designer`
+
+```markdown
+# [Project Name] — Designer Handoff
+**Date:** [today's date]
+
+## What This Is
+[2-3 sentences. Problem, audience, core value. What is the user's job?]
+
+## Design Principles
+[From VECTOR.md design principles — the philosophy that should drive every decision]
+
+## Token System
+[From ARCHITECTURE.md: where tokens live, how to reference them, any naming conventions]
+
+## Component / UI Layer
+[Layer name and directory for UI components. File naming convention. Where to put new components.]
+
+## Do Not
+[Design-relevant prohibitions: hardcoded values, going outside the token system, layout decisions that contradict declared principles]
+
+## Current Status
+[Project stage. What is designed vs. what is still TBD. Any design-relevant open questions from VECTOR.md.]
+
+## Where to Find Things
+- Product goals: VECTOR.md
+- Technical constraints: ARCHITECTURE.md
+- Design research: /vector/research/personas/, /vector/research/jtbd/
+```
+
+---
+
+### For `--role agent`
+
+```markdown
+# [Project Name] — Agent Session Brief
+**Date:** [today's date]
+
+## Reading Order
+VECTOR.md → CLAUDE.md → ARCHITECTURE.md. Read all three before touching code.
+
+## What This Project Is
+[3-4 sentences. Problem, audience, value proposition, current stage. Everything an agent needs to orient itself.]
+
+## Stack
+[Full stack table]
+
+## Layer Map
+[Full layer table with directories and boundary rules]
+
+## Import Direction
+[Explicit: which layers import from which. Violations are high severity.]
+
+## Naming Conventions
+[All declared conventions]
+
+## Do Not
+[Complete list of prohibitions from ARCHITECTURE.md and CLAUDE.md]
+
+## Commit Format
+[From CLAUDE.md]
+
+## Standup Format
+[From CLAUDE.md]
+
+## Current Status
+[Project stage. Doctrine health from most recent /vector/audits/invest-doctrine.md. Open violations from invest-architecture.md. Active missions if any.]
+
+## Open Questions
+[From VECTOR.md open questions — things the project is still uncertain about]
+
+## Where to Find Things
+- Assumptions: /vector/research/assumptions/
+- Decisions: /vector/decisions/
+- Audits: /vector/audits/
+- Active missions: /vector/missions/
+```
+
+---
+
+### For `--role client`
+
+```markdown
+# [Project Name] — Project Brief
+**Date:** [today's date]
+
+## What We're Building
+[3-4 sentences. Problem, audience, solution, why it matters. No technical detail.]
+
+## Who It's For
+[Target audience from VECTOR.md — specific, not generic]
+
+## Where We Are
+[Project stage in plain language: "We're in early testing with a small group of users" not "alpha stage"]
+
+## What's Working
+[Capabilities that are complete or stable — drawn from recent ADR decisions and project stage]
+
+## What's In Progress
+[Active missions if any. Current sprint focus in plain terms.]
+
+## What We're Still Learning
+[Open questions from VECTOR.md, framed as open questions not gaps]
+
+## Next Milestone
+[Quality gates or ship criteria from VECTOR.md, if filled in]
+```
+
+---
+
+### For generic (no role)
+
+```markdown
+# [Project Name] — Contributor Handoff
+**Date:** [today's date]
+
+## What This Is
+[3-4 sentences. Problem, audience, value proposition, stage.]
+
+## Stack
+[Abbreviated stack table]
+
+## Layer Map
+[Condensed layer table]
+
+## Do Not
+[Top 5 most important prohibitions]
+
+## Current Status
+[Stage, doctrine health, active missions]
+
+## Where to Find Things
+- Full doctrine: VECTOR.md → CLAUDE.md → ARCHITECTURE.md
+- Research: /vector/research/
+- Decisions: /vector/decisions/
+- Audits: /vector/audits/
+```
+
+---
+
+## Step 3: Output
+
+**Print the handoff to the terminal AND save it to `/vector/handoffs/[role]-[date].md`.**
+
+Use the role name in the filename. If no role was specified, use `generic`. Use today's date in YYYY-MM-DD format.
+
+Create the `/vector/handoffs/` directory if it does not exist.
+
+Do not overwrite existing handoffs for the same role and date — if the file exists, append `-2`, `-3`, etc. Handoffs are point-in-time snapshots, unlike audit files which reflect current state.
+
+**If `--dry-run` was passed:** Print the handoff to the terminal only. Do not write the file.
+
+After writing, output:
+
+```
+Handoff written to /vector/handoffs/[role]-[date].md
+
+[If any doctrine files were missing:]
+Warning: [filename] not found — [section] is incomplete in the handoff.
+
+[If doctrine audit showed violations:]
+Note: Most recent architecture audit found [N] high-severity violations. See /vector/audits/invest-architecture.md.
+```
+
+## Arguments
+
+- **No arguments:** Generic handoff suitable for any contributor
+- **`--role [engineer|designer|agent|client]`:** Role-specific handoff with appropriate depth and framing
+- **`--dry-run`:** Generates and displays the handoff without writing the file
+
+## Output
+
+`/vector/handoffs/[role]-[date].md`
+
+## When to Run
+
+- When onboarding a contractor or new team member — give them this before the doctrine files
+- Before starting a new agent session — use `--role agent` to generate the cold-start brief
+- Before a client check-in — use `--role client` for a stakeholder-ready summary
+- When handing off work between designers and engineers — `--role designer` and `--role engineer` give each side what they need without what they don't
+
+## Principles
+
+- **The right 20%, not everything.** A handoff that contains everything is not a handoff — it's the documentation. The value is in what it omits. Distill ruthlessly.
+- **Role determines depth.** An engineer needs layer boundaries and naming conventions. A client needs none of that. A cold agent session needs everything. The same project, four different documents.
+- **Current status matters as much as structure.** A handoff that describes the architecture but not the current health is missing half its value. Include audit findings and active missions.
+- **Doctrine is the source; handoff is the index.** The handoff tells you where to look, not everything you'll find. It points at VECTOR.md, ARCHITECTURE.md, and `/vector/` — it doesn't replace them.
+- **Sparse doctrine produces sparse handoffs.** If VECTOR.md is full of template placeholders, the handoff will be incomplete. That's honest — but flag it. An incomplete handoff is still better than no handoff.

--- a/.claude/skills/invest-handoff/SKILL.md
+++ b/.claude/skills/invest-handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-handoff
-description: "Generate a single condensed onboarding document for a human collaborator or cold agent session, tailored to a specific role. Reads VECTOR.md, CLAUDE.md, ARCHITECTURE.md, and current /vector/ state to tell someone exactly what they need to know to contribute without reading everything."
+description: "Generates a condensed onboarding document tailored to a specific role (engineer, designer, agent, client). Reads VECTOR.md, CLAUDE.md, ARCHITECTURE.md, and current /vector/ state. Use when onboarding a collaborator, starting a cold agent session, or preparing a client check-in."
 argument-hint: "[--role engineer|designer|agent|client] [--dry-run]"
 ---
 

--- a/.claude/skills/invest-interview/SKILL.md
+++ b/.claude/skills/invest-interview/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: invest-interview
+description: "Generate a user research discussion guide from unvalidated assumptions and open questions in /vector/. Produces a structured interview script with targeted questions, probing techniques, and clear signals for what validates or invalidates each assumption."
+argument-hint: "[--assumption id] [--theme topic] [--format [script|guide]] [--dry-run]"
+---
+
+# Investiture Skill: Interview Guide
+
+You are preparing someone to have a useful research conversation. A user interview without a guide wastes the participant's time and produces data you can't act on. This skill reads the project's open assumptions and questions, identifies what most needs testing, and produces a structured guide — specific questions, probing techniques, and clear criteria for what you're listening for — that a designer, PM, or researcher can pick up and run.
+
+**This skill runs before user research sessions.** It pairs with `/invest-validate`, which plans *what* to test and *how* (method selection). This skill produces the *actual guide* for conducting the session. After sessions, use `/invest-synthesize` to record what you learned.
+
+## Step 0: Determine Scope
+
+**If `--assumption [id]` was passed:** Scope the guide to validating that specific assumption. Build every question around probing it from multiple angles.
+
+**If `--theme [topic]` was passed:** Scope the guide to a specific topic area (e.g., "onboarding", "export flow", "pricing"). Include all assumptions and open questions relevant to that theme.
+
+**If no argument was passed:** Generate a general-purpose guide covering the highest-priority unvalidated assumptions across the full project.
+
+## Step 1: Read Research Context
+
+Read the following to understand what the project needs to learn:
+
+1. **`VECTOR.md`** — Extract:
+   - **Target audience** — who to recruit for research. This becomes the screener criteria.
+   - **Project stage** — informs appropriate session format and depth
+   - **Open questions** — things the project is explicitly uncertain about
+   - **Key assumptions** — if listed directly in VECTOR.md, note them
+
+2. **`/vector/research/assumptions/`** — Read all assumption files. For each, extract:
+   - ID and assumption text
+   - Validation status (`unvalidated`, `validated`, `invalidated`, `partial`)
+   - Risk level if declared
+   - Any existing evidence or notes
+
+   Focus on `unvalidated` and `partial` assumptions. Skip `validated` and `invalidated` unless the `--assumption` flag targets one specifically.
+
+3. **`/vector/research/personas/`** — Read all persona files. Extract:
+   - Relevant behaviors and context for the participant profile
+   - Known frustrations or pain points (these often make good interview entry points)
+   - What a representative participant looks like
+
+4. **`/vector/research/jtbd/`** — Read JTBD files relevant to the scope. Jobs provide the best interview structure — asking about the job surfaces context, obstacles, and workarounds naturally.
+
+5. **`/vector/research/interviews/`** — Scan existing interview files to understand what has already been asked. Avoid duplicating questions that have already produced clear answers.
+
+If `/vector/research/` does not exist, flag it: "Research directory not found. Run `/invest-backfill` to initialize the research structure." Continue using VECTOR.md open questions only.
+
+## Step 2: Select and Prioritize Assumptions to Probe
+
+If `--assumption [id]` was passed, use only that assumption. Skip this step.
+
+Otherwise, select the assumptions to include in the guide. Prioritize by risk:
+
+- **Include:** High-risk unvalidated assumptions (high impact + low confidence)
+- **Include:** Partial assumptions that need more data
+- **Include:** Open questions from VECTOR.md that map to the scope
+- **Skip:** Low-risk assumptions — not worth interview time
+- **Skip:** Already validated with strong evidence
+
+A single 45-60 minute session can meaningfully probe 3-5 assumptions. A 30-minute session: 2-3. Do not overload the guide.
+
+State the selected assumptions at the top of the guide output so the interviewer knows what they're trying to learn.
+
+## Step 3: Choose the Session Format
+
+**If `--format script` was passed:** Produce a word-for-word script. Every question is written out in full, including transitions and probes. Best for: first-time interviewers, high-stakes sessions, or when consistency across multiple sessions matters.
+
+**If `--format guide` was passed:** Produce a flexible topic guide. Each assumption gets a goal statement and 2-3 question options, not a rigid script. Best for: experienced interviewers who want structure but prefer to adapt in the moment.
+
+**If no format was passed:** Default to `guide` for projects in discovery or alpha stage. Default to `script` if: VECTOR.md lists multiple team members who might run sessions, CLAUDE.md describes the operator as a designer or developer (not a researcher), or the project stage is beta or later where session consistency matters more. When in doubt, default to `guide` — it is easier to follow rigidly than a script is to adapt flexibly.
+
+## Step 4: Write the Guide
+
+### Opening (all formats)
+
+```markdown
+## Opening (~5 minutes)
+
+**Goal:** Build rapport, set expectations, get the participant talking.
+
+"Thank you for making time. Before we start, a few things: I'm going to ask you about your experiences — there are no right or wrong answers. I'm not testing you; I'm trying to understand how you think about [topic area]. Please feel free to say 'I don't know' or 'that doesn't apply to me.' The more honest you are, the more useful this is.
+
+Do you mind if I take notes? [If recording:] Do you have any objections to me recording this for my own reference?
+
+To start — can you tell me a bit about how you [relevant activity related to the product domain]?"
+```
+
+### Per-assumption section
+
+For each assumption in scope, write a section:
+
+```markdown
+## [Assumption ID or theme name]
+
+**What we're trying to learn:** [The assumption in plain language — what the team believes and needs to test]
+**Why it matters:** [What goes wrong if this assumption is false]
+**Listen for:** [Specific signals that indicate the assumption is true or false — behaviors, language, emotions]
+
+### Questions
+
+**Entry question** (open-ended, no leading):
+"[Question that gets the participant talking about the relevant domain without revealing what you're looking for]"
+
+Example entry questions:
+- "Walk me through the last time you had to [relevant task]."
+- "Tell me about how you currently handle [problem area]."
+- "What does [activity] look like for you day-to-day?"
+
+**Probing questions** (follow wherever the entry question leads):
+- "Can you say more about that?"
+- "What happened next?"
+- "How did that make you feel?"
+- "What did you do instead?"
+- "Has that always been the case, or did something change?"
+
+**Targeted probes** (use only if the entry question didn't surface relevant context):
+- "[Specific question targeted at the assumption — only ask if the topic hasn't come up naturally]"
+- "[Another specific probe]"
+
+**What validates:** [Specific observable signals — what the participant says or describes that would confirm the assumption]
+Example: "Participant describes unprompted frustration with [X]" or "Participant uses a workaround that implies [pain]"
+
+**What invalidates:** [Specific signals that contradict the assumption]
+Example: "Participant has no awareness of [X] as a problem" or "Participant already has a satisfying solution"
+
+**Ambiguous signal:** [What to note if the response is mixed or unclear — and what follow-up question to ask]
+```
+
+### Closing (all formats)
+
+```markdown
+## Closing (~5 minutes)
+
+**Goal:** Catch anything missed, leave on a positive note.
+
+"We're coming up on time. Before we finish — is there anything about [topic area] that you wish I had asked about? Anything you've been thinking about while we talked that we haven't covered?
+
+[If appropriate:] Would you be open to a follow-up conversation as we continue this work?
+
+Thank you — this has been genuinely useful."
+```
+
+### Session logistics block
+
+Add at the end of the guide:
+
+```markdown
+## Session Logistics
+
+**Participant profile:** [Who to recruit — drawn from personas and VECTOR.md target audience. Be specific: role, experience level, relevant behaviors.]
+**Session length:** [Recommended time based on assumption count]
+**Format:** [In-person / video call / contextual inquiry]
+**Recording:** [Yes/No — note any consent requirements]
+**Materials needed:** [Any prototype, screenshots, or artifacts to show]
+
+## After the Session
+
+- Take notes within 30 minutes while memory is fresh
+- Note: which assumptions got signal, what the signal was (quote or observation), and what is still unclear
+- Run /invest-synthesize with your notes to update assumption files and VECTOR.md
+```
+
+## Step 5: Output
+
+**Print the guide to the terminal AND save it to `/vector/research/interviews/guide-[slug]-[date].md`.**
+
+Use a slug derived from the scope: the assumption ID, theme name, or `general`. Use today's date in YYYY-MM-DD format.
+
+Create `/vector/research/interviews/` if it does not exist.
+
+Do not overwrite existing guides for the same slug and date — if the file exists, append `-2`, `-3`, etc. Each guide is a snapshot for a specific session round.
+
+**If `--dry-run` was passed:** Print the guide to the terminal only. Do not write the file.
+
+After writing, output:
+
+```
+Interview guide written to /vector/research/interviews/guide-[slug]-[date].md
+
+Assumptions covered: [N] ([list IDs])
+Recommended session length: [N] minutes
+Format: [script | guide]
+
+Run /invest-synthesize after sessions to record findings and update assumptions.
+```
+
+## Arguments
+
+- **No arguments:** Full guide covering highest-priority unvalidated assumptions, flexible guide format
+- **`--assumption [id]`:** Guide scoped to one specific assumption
+- **`--theme [topic]`:** Guide scoped to a topic area across all related assumptions and open questions
+- **`--format [script|guide]`:** Override the default format selection
+- **`--dry-run`:** Generate and display the guide without writing the file
+
+## Output
+
+`/vector/research/interviews/guide-[slug]-[date].md`
+
+## When to Run
+
+- Before any user research session — do not run sessions without a guide
+- After `/invest-validate` identifies which assumptions to test — this produces the guide for the sessions that plan recommends
+- When onboarding a non-researcher to run interviews — use `--format script` for word-for-word guidance
+- After a product pivot — regenerate guides for assumptions that the pivot affected
+
+## Principles
+
+- **Open questions before targeted probes.** The best research surfaces what you didn't know to ask about. Start every assumption section with an open entry question that doesn't reveal what you're looking for. Reserve targeted probes for when the topic hasn't come up naturally.
+- **One assumption per section, not one question.** An assumption needs multiple angles — entry, probing, targeted. A single question can't validate or invalidate a belief about user behavior.
+- **Define the signal before the session.** "What validates" and "what invalidates" are written before the session, not after. This prevents confirmation bias — reading what you hoped to find into ambiguous responses.
+- **3-5 assumptions per session, maximum.** A guide that tries to cover eight assumptions covers none of them well. Depth beats breadth. If there are more assumptions to test, run more sessions.
+- **The guide serves the session; the session serves the research.** A guide is not a questionnaire to be read aloud. It is preparation that lets the interviewer stay present, follow interesting threads, and know when they've gotten the signal they came for.

--- a/.claude/skills/invest-interview/SKILL.md
+++ b/.claude/skills/invest-interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-interview
-description: "Generate a user research discussion guide from unvalidated assumptions and open questions in /vector/. Produces a structured interview script with targeted questions, probing techniques, and clear signals for what validates or invalidates each assumption."
+description: "Generates a structured user research discussion guide from unvalidated assumptions and open questions in /vector/. Produces targeted questions, probing techniques, and explicit validation signals per assumption. Use before any user research session."
 argument-hint: "[--assumption id] [--theme topic] [--format [script|guide]] [--dry-run]"
 ---
 

--- a/.claude/skills/invest-synthesize/SKILL.md
+++ b/.claude/skills/invest-synthesize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-synthesize
-description: "Take raw research input — interview notes, beta feedback, assumption validation results — extract structured insights, and propose specific patches to VECTOR.md and /vector/ schema files. Shows a full diff before writing anything."
+description: "Takes raw research input — interview notes, beta feedback, assumption validation results — extracts structured insights, and proposes specific patches to VECTOR.md and /vector/ schema files. Shows a full diff before writing anything. Use after user interviews or beta feedback rounds."
 argument-hint: "[--source file] [--dry-run]"
 ---
 

--- a/.claude/skills/invest-synthesize/SKILL.md
+++ b/.claude/skills/invest-synthesize/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: invest-synthesize
+description: "Take raw research input — interview notes, beta feedback, assumption validation results — extract structured insights, and propose specific patches to VECTOR.md and /vector/ schema files. Shows a full diff before writing anything."
+argument-hint: "[--source file] [--dry-run]"
+---
+
+# Investiture Skill: Synthesize Research
+
+You are closing the loop between what the project assumes and what you have actually learned. This skill takes raw research — interview notes, beta feedback, validation results, any qualitative or quantitative input — and turns it into doctrine updates. Not summaries. Not observations. Specific, proposed edits to the files the rest of the skill chain reads.
+
+**This skill pairs with `/invest-validate`.** Run `/invest-validate` to plan what to test. Run `/invest-synthesize` after sessions to record what you learned. It also pairs with `/invest-backfill` — backfill seeds `/vector/` schemas at project start; this skill updates them when reality diverges from the original assumptions.
+
+**Nothing is written without your approval.** This skill always shows a full diff of proposed changes and asks for confirmation before touching any file.
+
+## Step 0: Get the Input Source
+
+**If `--source [file]` was passed:** Read that file as the raw input. Accepted formats: Markdown, plain text, JSON, any readable format.
+
+**If no argument was passed:** Prompt the operator:
+
+```
+What research are you synthesizing? Provide one of:
+  1. A file path: path/to/interview-notes.md
+  2. Paste content directly (end with a blank line and "END")
+
+Types of input this skill handles:
+  - User interview transcripts or summaries
+  - Beta feedback (support tickets, survey responses, NPS comments)
+  - Assumption validation results (from /invest-validate sessions)
+  - Competitive analysis notes
+  - Analytics findings with interpretive context
+  - Any structured or unstructured research artifact
+```
+
+Read the input fully before doing anything else.
+
+## Step 1: Read Current Doctrine and Research State
+
+Read the following to understand what the project currently believes:
+
+1. **`VECTOR.md`** — Extract: current assumptions, open questions, audience description, value proposition, design principles, key constraints. You will propose patches to this file.
+2. **`/vector/research/assumptions/`** — Read all existing assumption files. Note which are validated, invalidated, or unvalidated.
+3. **`/vector/research/interviews/`** — Scan for existing interview files to understand what research has already been captured and avoid duplication.
+4. **`/vector/research/personas/`** — Scan for existing persona files.
+5. **`/vector/research/jtbd/`** — Scan for existing JTBD files.
+
+If `/vector/` does not exist, flag it: "The `/vector/` directory does not exist. Run `/invest-backfill` to initialize the research structure before synthesizing." Stop.
+
+If VECTOR.md is missing, flag it and continue — you can still update schema files even without doctrine.
+
+## Step 2: Extract Structured Insights
+
+Read the raw input and extract the following categories. Not everything will be present in every input — extract what exists.
+
+### 2a. Assumption Updates
+
+For each assumption mentioned or implied in the input:
+- **Confirmed:** Evidence supports an existing assumption → mark as `validated` with quote or data point as evidence
+- **Contradicted:** Evidence contradicts an existing assumption → mark as `invalidated` with specific evidence
+- **Partial:** Evidence is mixed or insufficient to fully validate or invalidate → mark as `partial` with notes
+- **New assumption surfaced:** The research revealed a belief the team is now holding that wasn't previously documented → flag as a new assumption to add
+
+For each update, note:
+- Which assumption file it affects (by ID or filename)
+- The specific evidence (direct quote, data point, or observation — not a summary)
+- The proposed new status
+
+### 2b. Persona Updates
+
+- **Confirmed persona attribute:** Something in the research confirms a trait, behavior, or need already in a persona file
+- **New persona attribute:** Research revealed something about users that isn't captured
+- **New persona:** Research revealed a distinct user type not yet documented — name the file `[persona-slug].md` (lowercase, hyphenated) in `/vector/research/personas/`
+- **Invalidated persona attribute:** Research contradicts something in an existing persona
+
+When creating a new persona file, use the same structure as existing persona files in `/vector/research/personas/`. If no existing files are present, use: name, description, goals, frustrations, relevant behaviors, and evidence source.
+
+### 2c. JTBD Updates
+
+Jobs to Be Done surfaced in the research:
+- **Confirmed JTBD:** Existing job description matches what users described
+- **Refined JTBD:** Job exists but the research gives a more precise description ("manage my workflow" → "recover from an interruption without losing context")
+- **New JTBD:** Research revealed a job not yet captured — name the file `[jtbd-slug].md` in `/vector/research/jtbd/`. Use the format: situation, job, outcome ("When [situation], I want to [job], so I can [outcome]"), plus evidence source.
+- **Dropped JTBD:** Users don't actually have this job — the team assumed it
+
+### 2d. Open Questions Surfaced
+
+Questions that the research raised but did not answer. These are candidates for VECTOR.md's "Open Questions" section and for the next `/invest-validate` run.
+
+### 2e. VECTOR.md Patches
+
+Based on what was learned, what in VECTOR.md should change?
+- **Audience description** — is it more specific now? Does it need a refinement?
+- **Assumptions section** — new assumptions to add, existing ones to update status
+- **Open Questions** — new questions to add, resolved questions to remove or archive
+- **Value proposition** — did the research sharpen or complicate the core value claim?
+- **Design principles** — did any principle prove wrong or need nuance?
+
+Do not propose changes to VECTOR.md sections unless the research specifically warrants it. Do not update for the sake of updating.
+
+## Step 3: Present the Extraction Summary
+
+Before proposing any file changes, present what you extracted:
+
+```
+## Synthesis Extraction — [input source]
+
+### Assumption Updates
+- [ID]: [current status] → [proposed status] — "[specific evidence]"
+- [ID]: NEW assumption — "[assumption text]"
+
+### Persona Updates
+- [file]: [what changes and why]
+
+### JTBD Updates
+- [file]: [what changes and why]
+
+### New Open Questions
+- [question]
+
+### VECTOR.md Patches Warranted
+- [section]: [what changes and why]
+
+### No Changes Warranted
+- [anything explicitly confirmed with no update needed]
+```
+
+Ask: "Does this extraction look accurate? Continue to diff?"
+
+If the operator says no or wants to adjust, address their feedback before continuing.
+
+## Step 4: Generate the Full Diff
+
+For every proposed change, show the exact before/after diff.
+
+For each file:
+
+```
+--- /vector/research/assumptions/[file].md (current)
++++ /vector/research/assumptions/[file].md (proposed)
+
+- status: unvalidated
++ status: validated
++ evidence: "[direct quote from research input]"
++ validated_date: [today's date]
+```
+
+For VECTOR.md patches:
+
+```
+--- VECTOR.md (current)
++++ VECTOR.md (proposed)
+
+  ### Open Questions
++ - Do users prefer inline editing or a dedicated settings panel? (surfaced in beta feedback round 2)
+```
+
+Show every proposed change before writing anything. If there are many changes, group them by file.
+
+After presenting the full diff, ask:
+
+```
+Proposed changes shown above.
+Apply all changes? Options:
+  - yes — write all changes
+  - no — discard all
+  - select — choose which changes to apply (list the numbers)
+```
+
+**If `--dry-run` was passed:** Present the extraction summary and full diff, then stop. Do not write anything.
+
+## Step 5: Write the Changes
+
+On confirmation, write only the approved changes.
+
+For each changed file:
+- Write the updated content
+- Do not change anything not listed in the approved diff
+
+After writing all files, create a synthesis audit trail:
+
+## Step 6: Write the Audit Trail
+
+**Save to `/vector/audits/invest-synthesize.md`.** Overwrite the file on each run — the current synthesis is what matters, git has the history.
+
+Audit trail format:
+
+```markdown
+# Synthesis Audit — [date]
+
+**Source:** [file path or "direct input"]
+**Date:** [today's date]
+
+## Changes Made
+
+### [filename]
+- [what changed and why — one line per change]
+
+## Evidence Summary
+
+[2-4 sentences summarizing what the research revealed at a high level]
+
+## Open Questions Added
+
+[List any new open questions surfaced, or "None"]
+
+## Next Steps
+
+[1-3 specific recommendations: what to validate next, what to update in VECTOR.md, what assumption needs a follow-up session]
+```
+
+Create `/vector/audits/` if it does not exist.
+
+**Print the audit trail to the terminal AND save it to `/vector/audits/invest-synthesize.md`.**
+
+After writing, output:
+
+```
+Synthesis complete.
+[N] files updated. Audit trail saved to /vector/audits/invest-synthesize.md
+
+Run /invest-validate to reprioritize assumptions based on updated statuses.
+Run /invest-doctrine to verify VECTOR.md is still internally consistent after patches.
+```
+
+## Arguments
+
+- **No arguments:** Prompts for input source interactively
+- **`--source [file]`:** Explicit input file path — skips the prompt
+- **`--dry-run`:** Extract, summarize, and show the full diff without writing any files
+
+## Output
+
+- Updated `/vector/research/assumptions/[id].md` files (status, evidence, date)
+- Updated `/vector/research/` schema files (personas, jtbd, interviews)
+- Updated `VECTOR.md` (assumptions section, open questions — only where warranted)
+- `/vector/audits/invest-synthesize.md` (audit trail, overwritten each run)
+
+## When to Run
+
+- After user interviews or usability sessions
+- After a beta feedback round
+- After running assumption validation experiments (post `/invest-validate` sessions)
+- After any structured research activity that produces findings about your users or assumptions
+
+## Principles
+
+- **Evidence, not summaries.** Every proposed change must cite specific evidence from the input — a direct quote, a data point, an observation. "Users seemed confused" is not evidence. "3 of 5 users tried to click the logo to go home" is.
+- **Propose, don't impose.** Always show the diff before writing. The operator decides what gets committed to doctrine.
+- **Scope to what research actually warrants.** If the research only addresses two assumptions, don't touch the rest of VECTOR.md. The skill should change what the evidence changes, nothing more.
+- **Invalidated is progress.** A wrong assumption updated to `invalidated` with evidence is a better outcome than leaving it `unvalidated`. Capture it.
+- **The audit trail is the memory.** `/vector/audits/invest-synthesize.md` is the record of what changed and why. It protects against drift — when someone asks "why does VECTOR.md say X?", the audit trail has the answer.

--- a/.claude/skills/invest-validate/SKILL.md
+++ b/.claude/skills/invest-validate/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: invest-validate
+description: "Read /vector/research/assumptions/, prioritize unvalidated assumptions by risk, and generate a lightweight, stage-appropriate validation plan. Turns a list of untested hypotheses into an actionable sprint."
+argument-hint: "[--assumption id] [--stage discovery|alpha|beta|launched] [--dry-run]"
+---
+
+# Investiture Skill: Validate Assumptions
+
+You are making the invisible visible. Assumptions parked in `/vector/research/assumptions/` are debt — they feel harmless until one of them is wrong in production. This skill reads every unvalidated assumption, assesses its risk, and generates a concrete plan for testing the highest-risk ones first.
+
+**This skill pairs with `/invest-synthesize`.** Run `/invest-validate` to build the plan. Run `/invest-synthesize` after you have data to update the assumption files with what you learned. If `/invest-synthesize` is not installed, update assumption files manually after validation sessions — the plan this skill generates is useful either way.
+
+## Step 1: Read Context
+
+Read the following to understand the project and its research state:
+
+1. **`VECTOR.md`** — Extract: target audience (who to test with), project stage (what validation methods are appropriate), constraints (budget, access, timeline), design principles.
+2. **`/vector/schemas/`** — If this directory contains an assumption schema file (e.g., `zv-assumption.json`), read it to understand the expected structure of assumption files.
+3. **`/vector/research/assumptions/`** — Read all assumption files in this directory. Assumption files may be Markdown with YAML frontmatter, plain Markdown with structured headings, or JSON. Read whatever format is present and extract the fields below. If the format is inconsistent or fields are missing, work with what exists and note gaps in the plan.
+
+   For each assumption, extract:
+   - **ID** — filename (without extension) or declared identifier field
+   - **Assumption text** — the belief being held
+   - **Validation status** — `unvalidated`, `validated`, `invalidated`, or undeclared (treat undeclared as `unvalidated`)
+   - **Risk level** — if declared, note it; otherwise you will assess it in Step 2
+   - **Evidence** — any existing validation notes, interview quotes, or data references
+
+If `VECTOR.md` is missing, flag it and proceed using only the assumptions files.
+
+If `/vector/research/assumptions/` does not exist or is empty, report: "No assumptions found in `/vector/research/assumptions/`. Run `/invest-backfill` to initialize the research structure, or create assumption files manually." Stop.
+
+**If `--assumption [id]` was passed:** Scope to only that assumption. Skip all others. If the specified ID is not found in `/vector/research/assumptions/`, report: "Assumption `[id]` not found in `/vector/research/assumptions/`. Available assumptions: [list all IDs found]." Stop.
+
+**If `--stage [stage]` was passed:** Use the provided stage to select validation methods. Otherwise, read the project stage from VECTOR.md.
+
+## Step 2: Classify Assumptions by Risk
+
+For each unvalidated assumption, assess risk using two dimensions:
+
+**Impact:** If this assumption is wrong, how badly does it affect the project?
+- **High:** Wrong assumption invalidates the core value proposition, causes a wasted feature build, or requires architectural rework
+- **Medium:** Wrong assumption requires adjusting approach, messaging, or a feature — significant but recoverable
+- **Low:** Wrong assumption causes minor friction or requires small adjustments
+
+**Confidence:** How much evidence exists that this assumption is correct?
+- **Low confidence:** No evidence, pure hypothesis, or contradicted by similar products
+- **Medium confidence:** Indirect evidence (analogous products, secondary research, team intuition with basis)
+- **High confidence:** Direct evidence from this product or audience (prior research, usage data, user quotes)
+
+**Risk score = Impact × (1 - Confidence):**
+- High impact + low confidence = **Critical** — test immediately
+- High impact + medium confidence = **High** — test this sprint
+- Medium impact + low confidence = **High** — test this sprint
+- High impact + high confidence = **Medium** — monitor, no active testing needed
+- Medium impact + medium confidence = **Medium** — test when sprint capacity allows
+- Low impact + any confidence = **Low** — test opportunistically
+
+Produce a risk table:
+
+```
+| ID | Assumption | Impact | Confidence | Risk | Status |
+|----|-----------|--------|-----------|------|--------|
+| [id] | [brief text] | High/Med/Low | Low/Med/High | Critical/High/Med/Low | unvalidated |
+```
+
+Sort by risk descending. Validated and invalidated assumptions appear at the bottom for reference.
+
+## Step 3: Select Stage-Appropriate Validation Methods
+
+Choose validation methods based on the project stage. Different stages have different access to users, data, and resources.
+
+### Discovery stage
+The product does not yet exist or is a prototype. Users haven't seen it.
+- **Appropriate:** Problem interviews ("Tell me about the last time you..."), Jobs-to-be-Done interviews, competitor usage observation, landing page smoke test, concierge test (manual simulation of the product)
+- **Avoid:** A/B tests (no traffic), analytics (no product), feature-level usability testing (no feature)
+
+### Alpha stage
+Product exists but is limited to a small, known group. Data is sparse.
+- **Appropriate:** Structured usability sessions (5 users), assumption validation interviews (show the product, ask targeted questions), qualitative surveys (open-ended), support channel analysis, direct observation sessions
+- **Avoid:** Quantitative A/B tests (insufficient sample), statistical significance claims
+
+### Beta stage
+Product is available to a broader audience. Enough data to detect patterns.
+- **Appropriate:** Analytics instrumentation + funnel analysis, quantitative surveys (targeted), A/B tests (if sufficient traffic), support ticket theme analysis, NPS with follow-up interviews, activation funnel analysis
+- **Both:** Qualitative validation still valuable for "why" context behind quantitative signals
+
+### Launched stage
+Product is in full production with a real user base.
+- **Appropriate:** All of the above, plus: cohort analysis, retention curve analysis, churn interviews, feature adoption tracking, customer advisory board sessions, longitudinal studies
+- **Emphasis shifts:** More quantitative, but qualitative still needed to explain anomalies
+
+## Step 4: Generate the Validation Plan
+
+For each **Critical** and **High** risk assumption, write a specific validation task:
+
+```
+### [Risk Level]: [Assumption ID] — [Brief assumption text]
+
+**Why this is risky:** [1 sentence — what goes wrong if the assumption is false]
+
+**Validation method:** [Specific method from Step 3, appropriate to project stage]
+
+**What to test:**
+[Specific question or hypothesis to test. Not "validate the assumption" — the actual thing to probe.]
+Example: "Does [target audience] currently struggle with [specific pain]? Ask: 'Walk me through the last time you had to [task].'"
+
+**Minimum signal:**
+[What result counts as validated? What counts as invalidated? Be specific.]
+Example: "3 of 5 interview participants describe unprompted pain with [task] → validated. Fewer than 2 → invalidated. Mixed → partial, needs follow-up."
+
+**Effort:** [Low / Medium / High]
+- Low: Can be done in < 2 hours (analytics check, 1-2 quick interviews, survey question addition)
+- Medium: Half-day effort (structured interview session, dedicated survey, analytics instrumentation)
+- High: Multi-day effort (usability study, experiment build, significant data analysis)
+
+**Who can validate this:** [User type, role, or data source needed — be specific]
+Example: "Existing users who have completed at least one [action]" or "Anyone in target audience — no prior product exposure needed"
+```
+
+For **Medium** risk assumptions, write briefer entries:
+
+```
+### Medium: [ID] — [Brief text]
+**Method:** [1-2 sentences — what to do and with whom]
+**Signal:** [What counts as validated/invalidated]
+```
+
+For **Low** risk assumptions, list them grouped:
+
+```
+### Low risk — test opportunistically
+- [ID]: [Brief text] — [One-sentence method when convenient]
+```
+
+## Step 5: Write the Sprint Summary
+
+End the plan with a prioritized sprint view:
+
+```
+## Validation Sprint Summary
+
+**Project stage:** [from VECTOR.md or --stage flag]
+**Total assumptions:** [N]
+**Unvalidated:** [N] | **Validated:** [N] | **Invalidated:** [N]
+
+### This sprint (Critical + High risk)
+[List assumption IDs and one-line validation task for each]
+
+### Next sprint (Medium risk)
+[List assumption IDs and one-line validation task for each]
+
+### Defer (Low risk)
+[Count and brief description]
+
+### Estimated effort this sprint
+[Sum of effort ratings — gives a rough sense of scope]
+```
+
+## Step 6: Output
+
+**Print the full plan to the terminal AND save it to `/vector/research/assumptions/validation-plan-[date].md`.**
+
+Use today's date in YYYY-MM-DD format for the filename. If a validation plan for today's date already exists, overwrite it — the current assessment is what matters, git has the history.
+
+Create `/vector/research/assumptions/` if it does not exist.
+
+**If `--dry-run` was passed:** Print the plan to the terminal only. Do not write the file.
+
+After writing, output:
+
+```
+Validation plan written to /vector/research/assumptions/validation-plan-[date].md
+
+[N] Critical, [N] High, [N] Medium, [N] Low risk assumptions.
+Run /invest-synthesize after your validation sessions to update the assumption files.
+(If /invest-synthesize is not installed, update assumption files manually.)
+```
+
+## Arguments
+
+- **No arguments:** Full assumption audit + validation plan for all unvalidated assumptions
+- **`--assumption [id]`:** Plan for one specific assumption only
+- **`--stage [discovery|alpha|beta|launched]`:** Override project stage for method selection. Useful when VECTOR.md stage is out of date or when planning ahead.
+- **`--dry-run`:** Generate and display the plan without writing the file
+
+## Output
+
+`/vector/research/assumptions/validation-plan-[date].md`
+
+## When to Run
+
+- At the start of a sprint, to decide what to test this cycle
+- After `/invest-synthesize` updates assumptions — new data may change risk rankings
+- Before major feature investment — validate the assumptions that justify it
+- After a pivot — your assumption set just changed; reprioritize
+
+## Principles
+
+- **Risk, not order.** High-impact, low-confidence assumptions get tested first. Not the oldest ones, not the ones easiest to test.
+- **Stage-appropriate methods.** A "run an A/B test" recommendation is useless in discovery. A "do 5 hallway tests" recommendation is useless when you have 50,000 users and a data team. Match the method to the moment.
+- **Specific signals, not vague validation.** "Validated" means something specific happened. Define the threshold before you test, not after.
+- **Invalidated is not failure.** A wrong assumption found cheaply is a win. Surface it. The goal is to find the wrong ones before building against them.
+- **This skill surfaces the debt.** After running validation sessions, update assumption files with what you learned — `/invest-synthesize` can help if installed, or do it manually. The plan is only useful if the results come back.

--- a/.claude/skills/invest-validate/SKILL.md
+++ b/.claude/skills/invest-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: invest-validate
-description: "Read /vector/research/assumptions/, prioritize unvalidated assumptions by risk, and generate a lightweight, stage-appropriate validation plan. Turns a list of untested hypotheses into an actionable sprint."
+description: "Reads /vector/research/assumptions/, prioritizes unvalidated assumptions by risk (Impact × Confidence), and generates a stage-appropriate validation plan. Use at the start of a sprint or before major feature investment to turn untested hypotheses into an actionable plan."
 argument-hint: "[--assumption id] [--stage discovery|alpha|beta|launched] [--dry-run]"
 ---
 


### PR DESCRIPTION
## What this adds

Eight new SKILL.md files covering the territory v1.3 left open: research loop, design preparation, fleet coordination, and stakeholder communication.

**Research loop:**
- `invest-validate` — reads `/vector/research/assumptions/`, classifies by risk (Impact × Confidence), produces a stage-appropriate validation sprint plan
- `invest-synthesize` — takes raw research input, extracts structured insights, proposes specific patches to VECTOR.md and `/vector/` schema files, shows full diff before writing anything
- `invest-interview` — generates structured user research discussion guides from unvalidated assumptions, with entry questions, probing techniques, and explicit validation/invalidation signals per assumption

**Design prep:**
- `invest-brief` — generates a design brief for a specific feature or flow from existing personas, JTBD, assumptions, and doctrine; optimized for UX/UI designers and non-engineers
- `invest-adr` — generates numbered ADRs from a decision description, reading VECTOR.md constraints and existing decisions to avoid contradictions

**Fleet and release:**
- `invest-crew` — decomposes a feature into atomic agent tasks with branch names, commit prefixes, and scope boundaries; output lands in `/vector/missions/`
- `invest-handoff` — generates role-specific onboarding docs (engineer, designer, agent, client) from all three doctrine files + current `/vector/` state
- `invest-changelog` — reads git log since last tag, filters internal noise, groups by user-facing theme, writes plain-language changelog keyed to the value prop

## What changed in `/vector/`

Three new directories created by these skills (not by `invest-backfill`):
- `/vector/missions/` — crew task manifests
- `/vector/handoffs/` — point-in-time onboarding snapshots
- `/vector/changelog/` — versioned release notes
- `/vector/briefs/` — design briefs
- `/vector/audits/invest-synthesize.md` — synthesis audit trail (overwrites each run)

Note: `invest-backfill` does not create these directories. Each skill creates its output directory if it doesn't exist.

## Conventions followed

- All skills follow the v1.3 SKILL.md format: YAML frontmatter, `# Investiture Skill: [Short Title]`, "You are..." opening, bold chain-positioning statement, numbered steps, Arguments, Output, When to Run, Principles
- Overwrite vs. snapshot: audit files overwrite; briefs, handoffs, interview guides are snapshots (no-overwrite, appends `-2`, `-3`)
- All file-writing skills have `--dry-run`
- All paths use `/vector/research/assumptions/` (not `/vector/assumptions/`)

## Not in this PR

`invest-backfill` still only scaffolds the v1.3 directory structure. If you want it to pre-create the v1.4 directories, that's a separate change.