### PR TITLE
Add active doctrine enforcement: invest-bootstrap and invest-check

### DIFF
--- a/.claude/skills/invest-bootstrap/SKILL.md
+++ b/.claude/skills/invest-bootstrap/SKILL.md
@@ -1,0 +1,77 @@
+# invest-bootstrap
+
+Make the agent aware of Investiture. Updates CLAUDE.md so the agent knows to read doctrine files and invoke skills periodically.
+
+This is the "make it stick" skill. Without it, agents generate code but ignore the doctrine sitting in the repo. This skill writes the instructions that make agents follow the methodology.
+
+---
+
+## When to run
+
+- After `/invest-backfill` generates doctrine files
+- When an agent keeps ignoring VECTOR.md or ARCHITECTURE.md
+- When onboarding a new agent or persona to an existing Investiture project
+- When CLAUDE.md exists but doesn't reference the doctrine system
+
+## What it does
+
+1. **Read existing CLAUDE.md** (if it exists). Note what's already there — never destroy existing content.
+
+2. **Check for doctrine files.** Verify that VECTOR.md, CLAUDE.md, and ARCHITECTURE.md exist. If any are missing, tell the operator which ones are missing and suggest running `/invest-backfill` first. Do not proceed without at least VECTOR.md and ARCHITECTURE.md.
+
+3. **Check for an Investiture section in CLAUDE.md.** Look for a section titled "## Investiture" or "## Doctrine" or "## Skills". If one already exists, report what's there and ask the operator if they want to update it. Do not overwrite without asking.
+
+4. **Add the Investiture section to CLAUDE.md.** Append (do not replace existing content) a section that includes:
+
+```markdown
+## Investiture
+
+This project uses [Investiture](https://github.com/erikaflowers/investiture) for structured doctrine and agent-first design.
+
+### Reading order
+
+Before writing any code, read these files in order:
+
+1. **VECTOR.md** — Project doctrine. Why this exists, who it serves, constraints.
+2. **CLAUDE.md** — This file. Contributor onboarding.
+3. **ARCHITECTURE.md** — Technical authority. Layers, naming, imports, conventions.
+
+ARCHITECTURE.md is the single technical authority. When in doubt about where a file goes or how to name it, ARCHITECTURE.md decides.
+
+### Skills
+
+Run these as needed — they are not meant to be run all at once:
+
+| Skill | When to use |
+|-------|-------------|
+| `/invest-doctrine` | After editing any doctrine file. Validates completeness and consistency. |
+| `/invest-architecture` | Before a commit or PR. Checks code follows declared conventions. |
+| `/invest-check` | Quick preflight before starting work. Confirms doctrine is loaded and current. |
+
+### Working with doctrine
+
+- **Before starting a task:** Read VECTOR.md to understand why. Read ARCHITECTURE.md to understand how.
+- **Before committing:** Run `/invest-architecture` to verify conventions.
+- **When unsure about a decision:** Check if VECTOR.md or ARCHITECTURE.md already answers it. If not, make the decision and record it in `/vector/decisions/`.
+- **Do not ignore doctrine files.** They exist because someone made deliberate decisions about this project. Follow them.
+```
+
+5. **Verify the section was added.** Re-read CLAUDE.md and confirm the Investiture section is present and well-formed.
+
+6. **Report what changed.** Show the operator:
+   - What was added to CLAUDE.md
+   - Whether doctrine files were found
+   - Any missing files or incomplete sections
+   - Suggested next step (usually: "Run `/invest-doctrine` to validate your doctrine")
+
+## Arguments
+
+- No arguments. This skill reads the project state and acts accordingly.
+
+## Rules
+
+- **Never overwrite existing CLAUDE.md content.** Append only.
+- **Never create VECTOR.md or ARCHITECTURE.md.** That's `/invest-backfill`'s job.
+- **If CLAUDE.md doesn't exist at all,** create it from the Investiture template (see the CLAUDE.md template in this repo) and add the Investiture section.
+- **Be explicit about what you changed.** The operator should be able to review the diff.
+- **This skill is idempotent.** Running it twice should not duplicate the section.

--- a/.claude/skills/invest-check/SKILL.md
+++ b/.claude/skills/invest-check/SKILL.md
@@ -1,0 +1,87 @@
+# invest-check
+
+Quick preflight check before starting work. Confirms doctrine is loaded, current, and the agent knows the rules.
+
+This is the lightweight "are we good?" skill. Run it at the start of a session, before a major task, or when you suspect the agent has drifted from the project's conventions.
+
+---
+
+## When to run
+
+- At the start of a work session
+- Before starting a new feature or significant change
+- When an agent seems to be ignoring doctrine
+- As a sanity check before a commit
+
+## What it does
+
+1. **Check doctrine files exist.** Look for VECTOR.md, CLAUDE.md, and ARCHITECTURE.md at the project root. Report which exist and which are missing.
+
+2. **Check doctrine is non-empty.** A file that exists but contains only template placeholders (`[OPERATOR: ...]`) is not filled in. Flag any doctrine file that is still a template.
+
+3. **Read ARCHITECTURE.md.** Extract:
+   - Layer table (names and locations)
+   - Naming conventions (casing rules)
+   - Import direction rules
+   - Any "What Not to Do" section
+
+4. **Read VECTOR.md.** Extract:
+   - Project name and description
+   - Target audience
+   - Design principles
+   - Constraints
+
+5. **Read CLAUDE.md.** Check for:
+   - An Investiture section (reading order, skill references)
+   - Stack summary
+   - Key context
+   - What not to do
+
+6. **Spot-check the codebase.** Pick 3 files at random from `src/` (or the primary source directory declared in ARCHITECTURE.md). For each file, check:
+   - Does the filename follow declared naming conventions?
+   - Are imports consistent with declared direction rules?
+   - Is the file in the correct layer?
+
+   This is not a full audit — that's `/invest-architecture`. This is a quick sample to catch obvious drift.
+
+7. **Report.** Print a concise status:
+
+```
+Investiture check — [project name]
+
+Doctrine:
+  ✓ VECTOR.md — filled in
+  ✓ CLAUDE.md — has Investiture section
+  ✓ ARCHITECTURE.md — 4 layers, 3 naming rules
+
+Spot check (3 files):
+  ✓ src/components/Header.jsx — correct layer, naming OK
+  ✓ src/App.jsx — correct layer, naming OK
+  ✗ services/api.js — imports from components/ (violates layer rule)
+
+Status: 1 issue found. Run /invest-architecture for full audit.
+```
+
+If everything passes:
+
+```
+Investiture check — [project name]
+
+Doctrine: all 3 files present and filled in
+Spot check: 3/3 files clean
+CLAUDE.md: Investiture section present
+
+Ready to work. Doctrine loaded.
+```
+
+## Arguments
+
+- `/invest-check` — run the full preflight
+- `/invest-check --quiet` — only report problems, skip the full output if everything is clean
+
+## Rules
+
+- **This skill never writes files.** It is read-only. It checks, it reports, it's done.
+- **Keep it fast.** Check 3 files, not the whole codebase. The point is a quick signal, not a full audit.
+- **Be honest about what you found.** If doctrine is missing or stale, say so clearly.
+- **Suggest the right next step.** Missing doctrine → `/invest-backfill`. Stale doctrine → `/invest-doctrine`. Code drift → `/invest-architecture`. No Investiture section in CLAUDE.md → `/invest-bootstrap`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ This adds:
 - `vector/schemas/` -- Six research schemas (persona, JTBD, assumption, interview, competitive, blue ocean)
 - `vector/research/`, `vector/decisions/`, `vector/audits/` -- Directory structure for structured findings
 
-Then open Claude Code and run `/invest-backfill`. It surveys your codebase and generates VECTOR.md, CLAUDE.md, and ARCHITECTURE.md.
+Then open Claude Code and run:
+
+1. `/invest-backfill` — surveys your codebase and generates VECTOR.md, CLAUDE.md, and ARCHITECTURE.md
+2. Review the generated files and fill in the `[OPERATOR: ...]` sections
+3. `/invest-bootstrap` — writes Investiture instructions into CLAUDE.md so your agent follows doctrine
+4. `/invest-doctrine` — validates everything is sound
 
 **Alternative (no npm):**
 
@@ -117,16 +122,22 @@ vector/
 
 The skill chain reads your doctrine at runtime and enforces it. Skills live in `.claude/skills/` and are auto-discovered by Claude Code.
 
+### Core skills
+
 | Skill | Purpose |
 |-------|---------|
 | `/invest-backfill` | Survey an existing codebase and generate starter doctrine |
+| `/invest-bootstrap` | Write Investiture instructions into CLAUDE.md so agents follow doctrine |
+| `/invest-check` | Quick preflight — confirm doctrine is loaded and current |
 | `/invest-doctrine` | Validate doctrine for completeness, consistency, and drift |
 | `/invest-architecture` | Audit code against declared layers, imports, naming, tokens |
 
-**Existing projects:** Run `/invest-backfill` first. It surveys your code and generates VECTOR.md, CLAUDE.md, and ARCHITECTURE.md.
-**Greenfield projects:** Fill in the three doctrine files, then run `/invest-doctrine` to validate.
+**Existing projects:** Run `/invest-backfill` first, then `/invest-bootstrap` to make the agent follow it.
+**Greenfield projects:** Fill in the three doctrine files, run `/invest-bootstrap`, then `/invest-doctrine` to validate.
 
-The chain runs in order: backfill creates the doctrine, doctrine validates it, architecture enforces it.
+The chain: backfill creates the doctrine, bootstrap makes agents follow it, check confirms it's loaded, doctrine validates it, architecture enforces it.
+
+Extended skills for planning, research, governance, and team workflows are available in v1.5. See [invest.md](invest.md) for the full list and tiers.
 
 See [invest.md](invest.md) for the full skill chain reference.
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ vector/
 
 The skill chain reads your doctrine at runtime and enforces it. Skills live in `.claude/skills/` and are auto-discovered by Claude Code.
 
-### Core skills
-
 | Skill | Purpose |
 |-------|---------|
 | `/invest-backfill` | Survey an existing codebase and generate starter doctrine |
@@ -134,10 +132,9 @@ The skill chain reads your doctrine at runtime and enforces it. Skills live in `
 
 **Existing projects:** Run `/invest-backfill` first, then `/invest-bootstrap` to make the agent follow it.
 **Greenfield projects:** Fill in the three doctrine files, run `/invest-bootstrap`, then `/invest-doctrine` to validate.
+**Ongoing sessions:** Run `/invest-check` at session start, `/invest-architecture` before committing.
 
-The chain: backfill creates the doctrine, bootstrap makes agents follow it, check confirms it's loaded, doctrine validates it, architecture enforces it.
-
-Extended skills for planning, research, governance, and team workflows are available in v1.5. See [invest.md](invest.md) for the full list and tiers.
+See [invest.md](invest.md) for the full skill reference, tiers, and version history.
 
 See [invest.md](invest.md) for the full skill chain reference.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,22 +1,59 @@
 # Getting Started
 
-## Quick Start
+## Two paths
+
+### Path A: Add to an existing project
+
+```bash
+npx investiture init
+```
+
+Then open Claude Code:
+
+```bash
+claude
+```
+
+Run the core chain in order:
+
+```bash
+/invest-backfill          # Survey your project, generate doctrine files
+# Review generated files. Fill in [OPERATOR: ...] sections.
+/invest-bootstrap         # Write Investiture instructions into CLAUDE.md
+/invest-doctrine          # Validate doctrine is complete and consistent
+/invest-architecture      # Check code against declared conventions
+```
+
+On future sessions:
+
+```bash
+/invest-check             # Quick preflight — is doctrine loaded?
+# ... work ...
+/invest-architecture      # Verify before committing
+```
+
+### Path B: Start a new project
 
 ```bash
 git clone https://github.com/erikaflowers/investiture.git my-project
-cd my-project
-bash install.sh
+cd my-project && bash install.sh
 npm run start
 ```
 
-## Make It Yours
+Then:
 
-1. **Read VECTOR.md** — Fill in your project identity, audience, and constraints
-2. **Read CLAUDE.md** — Customize the agent persona for your project
-3. **Read ARCHITECTURE.md** — Understand the layers, add your stack choices
-4. **Start building** — Open Claude Code and say "Add a feature"
+1. **Edit VECTOR.md** — Fill in your project identity, audience, and constraints
+2. **Edit CLAUDE.md** — Add your stack summary, key context, what not to do
+3. **Edit ARCHITECTURE.md** — Define your layers, conventions, naming rules
 
-## File Reading Order
+Open Claude Code and run:
+
+```bash
+/invest-bootstrap         # Write Investiture instructions into CLAUDE.md
+/invest-doctrine          # Validate your filled-in doctrine
+```
+
+## File reading order
 
 For humans and AI agents alike:
 
@@ -25,6 +62,31 @@ For humans and AI agents alike:
 3. `ARCHITECTURE.md` — *What* the technical implementation looks like
 4. `README.md` — Public-facing documentation
 
-## Project Structure
+## Why `/invest-bootstrap` matters
+
+Doctrine files are passive. Your agent reads CLAUDE.md when it opens the project, but it doesn't re-read VECTOR.md or ARCHITECTURE.md every time it writes code.
+
+`/invest-bootstrap` solves this by writing explicit instructions into CLAUDE.md that tell the agent:
+- Read the doctrine files before starting work
+- Follow ARCHITECTURE.md as the technical authority
+- Run `/invest-check` at session start
+- Run `/invest-architecture` before committing
+
+Without this step, you have doctrine files sitting in your repo that agents ignore.
+
+## What if my agent still ignores doctrine?
+
+1. Run `/invest-check` — it will tell you if doctrine is missing, incomplete, or if the agent hasn't loaded it
+2. Run `/invest-bootstrap` again — it re-establishes the instructions in CLAUDE.md
+3. Make sure CLAUDE.md has the Investiture section — without it, the agent has no reason to check the other files
+
+## Skill tiers
+
+Not every skill is for every project. See [invest.md](../invest.md) for the full breakdown:
+
+- **Core** (5 skills) — bootstrapping, validation, enforcement. Every project needs these.
+- **Extended** (21+ skills) — planning, research, governance, team workflows. Pick what fits.
+
+## Project structure
 
 See ARCHITECTURE.md for the full breakdown.

--- a/invest.md
+++ b/invest.md
@@ -18,11 +18,17 @@ These handle bootstrapping, enforcement, and the ongoing work loop. Every Invest
 | `/invest-doctrine` | Validate doctrine for completeness, consistency, and drift | After editing doctrine files |
 | `/invest-architecture` | Audit code against declared layers, imports, naming, tokens | Before commits and PRs |
 
-### Extended Skills (optional)
+### Extended Skills (v1.5, optional)
 
-These add capabilities for teams that need them. Pick the ones that match your workflow — you don't need all of them.
+These add capabilities for teams that need them. They are organized into groups. Pick the ones that match your workflow — you don't need all of them.
 
-See the v1.5 skills branch for the full set. Extended skills cover planning (`invest-prd`, `invest-scope`, `invest-brief`), research (`invest-interview`, `invest-synthesize`, `invest-benchmark`), governance (`invest-compliance`, `invest-risk`, `invest-contract`), and team workflows (`invest-crew`, `invest-status`, `invest-retro`, `invest-handoff`).
+| Group | Skills | What they cover |
+|-------|--------|----------------|
+| Getting Started | `invest-start`, `invest-init` | Guided onboarding for first-time users. `invest-start` detects project state and recommends a skill path. `invest-init` runs guided setup for new projects. |
+| Research | `invest-interview`, `invest-synthesize`, `invest-validate`, `invest-capture` | User research loop: generate guides, extract insights, prioritize assumptions, capture learnings. |
+| Planning | `invest-prd`, `invest-scope`, `invest-brief`, `invest-adr`, `invest-metrics`, `invest-crew` | Product planning: PRDs, scope decomposition, design briefs, ADRs, success metrics, multi-agent task breakdown. |
+| Client | `invest-proposal`, `invest-contract`, `invest-status`, `invest-handoff`, `invest-changelog` | Client-facing artifacts: proposals, deliverable manifests, status reports, onboarding docs, release notes. |
+| Governance | `invest-benchmark`, `invest-risk`, `invest-compliance`, `invest-dependency`, `invest-trace`, `invest-retro` | Maturity scoring, risk registers, regulatory mapping, dependency health, traceability, retrospectives. |
 
 ---
 
@@ -50,7 +56,9 @@ After initial setup, the ongoing loop is:
 /invest-check → work → /invest-architecture → commit
 ```
 
-For greenfield projects (created from the Investiture template), start at `/invest-bootstrap` — the templates are already there. For existing projects being retrofitted, start at `/invest-backfill`.
+**New to Investiture?** Run `/invest-start` (v1.5) — it detects your project state and gives you a sequenced path.
+**Greenfield projects:** Run `/invest-init` (v1.5) for guided setup, or fill in the templates and run `/invest-bootstrap`.
+**Existing projects:** Run `/invest-backfill` → `/invest-bootstrap` → `/invest-doctrine`.
 
 ### Invocation Order
 

--- a/invest.md
+++ b/invest.md
@@ -2,27 +2,55 @@
 
 **Active skills for this project.** Each skill reads your doctrine files and enforces what you've written.
 
-## The Chain
+## Skill Tiers
 
-Skills run in order. Each one depends on the one before it.
+Not every skill is meant for every project. Investiture has a focused core and optional extensions.
+
+### Core Skills
+
+These handle bootstrapping, enforcement, and the ongoing work loop. Every Investiture project uses these.
+
+| Skill | Purpose | When to run |
+|-------|---------|-------------|
+| `/invest-backfill` | Survey an existing codebase and generate VECTOR.md, CLAUDE.md, ARCHITECTURE.md | Once, when adopting Investiture |
+| `/invest-bootstrap` | Write Investiture instructions into CLAUDE.md so agents follow doctrine | After backfill, or when agents ignore doctrine |
+| `/invest-check` | Quick preflight — confirm doctrine is loaded and current | Start of session, before major work |
+| `/invest-doctrine` | Validate doctrine for completeness, consistency, and drift | After editing doctrine files |
+| `/invest-architecture` | Audit code against declared layers, imports, naming, tokens | Before commits and PRs |
+
+### Extended Skills (optional)
+
+These add capabilities for teams that need them. Pick the ones that match your workflow — you don't need all of them.
+
+See the v1.5 skills branch for the full set. Extended skills cover planning (`invest-prd`, `invest-scope`, `invest-brief`), research (`invest-interview`, `invest-synthesize`, `invest-benchmark`), governance (`invest-compliance`, `invest-risk`, `invest-contract`), and team workflows (`invest-crew`, `invest-status`, `invest-retro`, `invest-handoff`).
+
+---
+
+## The Core Chain
+
+The five core skills run in a specific order. Each one builds on the one before it.
 
 ```
-/invest-backfill       →  Bootstrap: creates doctrine from an existing project
+/invest-backfill       →  Survey project, generate doctrine
+        ↓
+/invest-bootstrap      →  Write Investiture instructions into CLAUDE.md
+        ↓
+/invest-check          →  Quick preflight (run anytime)
+        ↓
 /invest-doctrine       →  Is the doctrine sound?
+        ↓
 /invest-architecture   →  Does the code follow the doctrine?
 ```
 
-Backfill creates the doctrine. Doctrine validates it. Architecture enforces it.
+Backfill creates the doctrine. Bootstrap makes the agent follow it. Check confirms it's loaded. Doctrine validates it. Architecture enforces it.
 
-For greenfield projects (created from the Investiture template), start at `/invest-doctrine` — the templates are already there. For existing projects being retrofitted, start at `/invest-backfill`.
+After initial setup, the ongoing loop is:
 
-## Active Skills
+```
+/invest-check → work → /invest-architecture → commit
+```
 
-| Skill | Purpose | Invocation |
-|-------|---------|------------|
-| `invest-backfill` | Surveys an existing codebase and generates VECTOR.md, CLAUDE.md, and ARCHITECTURE.md by combining Investiture defaults with inferred project patterns | `/invest-backfill` |
-| `invest-doctrine` | Audits VECTOR.md, CLAUDE.md, and ARCHITECTURE.md for completeness, consistency, contradictions, and drift from reality | `/invest-doctrine` |
-| `invest-architecture` | Audits the codebase against layers, naming, imports, tokens, and conventions declared in ARCHITECTURE.md | `/invest-architecture` |
+For greenfield projects (created from the Investiture template), start at `/invest-bootstrap` — the templates are already there. For existing projects being retrofitted, start at `/invest-backfill`.
 
 ### Invocation Order
 
@@ -38,20 +66,26 @@ For greenfield projects (created from the Investiture template), start at `/inve
 # Generate only a specific doctrine file
 /invest-backfill --only architecture
 
-# 2. Validate the generated doctrine
+# 2. Make the agent follow doctrine
+/invest-bootstrap
+
+# 3. Validate the generated doctrine
 /invest-doctrine
 
-# 3. Check the code against doctrine
+# 4. Check the code against doctrine
 /invest-architecture
 ```
 
 **Greenfield project (from Investiture template):**
 
 ```bash
-# 1. Check the doctrine itself
+# 1. Write Investiture section into CLAUDE.md
+/invest-bootstrap
+
+# 2. Check the doctrine itself
 /invest-doctrine
 
-# 2. If doctrine is sound, check the code against it
+# 3. If doctrine is sound, check the code against it
 /invest-architecture
 
 # Scope either skill to a specific file
@@ -62,12 +96,36 @@ For greenfield projects (created from the Investiture template), start at `/inve
 /invest-architecture --fix
 ```
 
+**Ongoing work sessions:**
+
+```bash
+# Quick preflight at start of session
+/invest-check
+
+# ... do your work ...
+
+# Verify before committing
+/invest-architecture
+```
+
 ### When to Run Each Skill
 
 Run `/invest-backfill` when:
 - You have an existing project with no doctrine files
 - You adopted Investiture but never filled in the templates
 - You want to understand what Investiture would infer about your project (`--dry-run`)
+
+Run `/invest-bootstrap` when:
+- After `/invest-backfill` generates doctrine files
+- When agents keep ignoring VECTOR.md or ARCHITECTURE.md
+- When onboarding a new agent to an Investiture project
+- When CLAUDE.md exists but doesn't reference the doctrine system
+
+Run `/invest-check` when:
+- At the start of a work session
+- Before starting a new feature or significant change
+- When an agent seems to be ignoring doctrine
+- As a quick sanity check before a commit
 
 Run `/invest-doctrine` when:
 - You have edited any doctrine file (VECTOR.md, CLAUDE.md, ARCHITECTURE.md)
@@ -79,16 +137,6 @@ Run `/invest-architecture` when:
 - You want to verify the codebase follows declared conventions
 - Before a commit or PR, as a structural check
 - After significant refactoring
-
-## Forthcoming
-
-| Skill | Purpose | Depends On | Version |
-|-------|---------|------------|---------|
-| `invest-alignment` | Traces features to user needs defined in VECTOR.md | `invest-doctrine` | v1.3 |
-| `invest-provenance` | Links design decisions to research artifacts in /vector | `invest-doctrine` | v1.3 |
-| `invest-onboarding` | Ensures doctrine stack is read before contributing | `invest-doctrine` | v1.3 |
-
-All forthcoming skills depend on `invest-doctrine`. Sound doctrine is the foundation the entire chain trusts.
 
 ## Adopting Investiture on an Existing Project
 
@@ -111,8 +159,10 @@ cp -r /tmp/investiture/.claude/skills/* .claude/skills/
 rm -rf /tmp/investiture
 ```
 
-This copies three skill directories into your project:
+This copies the core skill directories into your project:
 - `.claude/skills/invest-backfill/` — generates doctrine from your existing code
+- `.claude/skills/invest-bootstrap/` — writes Investiture instructions into CLAUDE.md
+- `.claude/skills/invest-check/` — quick preflight before work
 - `.claude/skills/invest-doctrine/` — validates doctrine files
 - `.claude/skills/invest-architecture/` — enforces code against doctrine
 
@@ -130,6 +180,7 @@ Backfill will survey your codebase — README, package manifest, directory struc
 Backfill generates drafts. Review the `[OPERATOR: ...]` sections and fill in what it couldn't infer. Then:
 
 ```bash
+/invest-bootstrap       # Make the agent follow doctrine
 /invest-doctrine        # Validate the doctrine is sound
 /invest-architecture    # Check code against doctrine
 ```
@@ -147,6 +198,8 @@ Each skill saves its report to `/vector/audits/`:
 | Skill | Report |
 |-------|--------|
 | `invest-backfill` | `/vector/audits/invest-backfill.md` |
+| `invest-bootstrap` | (no report — modifies CLAUDE.md directly) |
+| `invest-check` | (no report — prints to console only) |
 | `invest-doctrine` | `/vector/audits/invest-doctrine.md` |
 | `invest-architecture` | `/vector/audits/invest-architecture.md` |
 
@@ -161,6 +214,60 @@ Each skill reads your project's doctrine files — `VECTOR.md`, `CLAUDE.md`, `AR
 ### Customize
 
 Skills respect your customizations. If you change the stack, swap conventions, add layers, or rewrite your design principles — the skills adapt to YOUR doctrine, not a preset. `invest-backfill` infers from your actual project. `invest-doctrine` checks that your doctrine is internally consistent. `invest-architecture` checks that your code follows it.
+
+## First 5 Minutes
+
+You just installed Investiture on an existing project. Here's what happens.
+
+**Minute 0-1: Install.**
+`npx investiture init` adds `.claude/skills/` and `vector/` to your project. Your code is untouched.
+
+**Minute 1-2: Open Claude Code.**
+Run `claude` in your project. Claude Code auto-discovers the skills in `.claude/skills/`.
+
+**Minute 2-3: Backfill.**
+Run `/invest-backfill`. The agent reads your README, package.json, config files, directory structure, and git history. It generates VECTOR.md, CLAUDE.md, and ARCHITECTURE.md with `[OPERATOR: ...]` prompts for things it couldn't infer.
+
+**Minute 3-4: Review.**
+Open the generated files. Fill in the `[OPERATOR: ...]` sections — who your users are, what your constraints are, what trade-offs you've made. The agent inferred what it could. You fill in the rest.
+
+**Minute 4-5: Bootstrap.**
+Run `/invest-bootstrap`. This writes an Investiture section into CLAUDE.md that tells the agent to read doctrine files and follow them. Without this step, the doctrine exists but the agent doesn't know to check it.
+
+**You're set.** On future sessions, run `/invest-check` as a quick preflight, then work normally. Run `/invest-architecture` before committing.
+
+---
+
+## Why Agents Don't Follow Doctrine Automatically
+
+Doctrine files are passive. An agent reads CLAUDE.md when it opens a project, but it doesn't re-read VECTOR.md or ARCHITECTURE.md every time it writes code. If the agent isn't explicitly told to check doctrine, it will drift.
+
+This is why Investiture uses active skills, not just passive docs:
+
+- **`/invest-bootstrap`** writes instructions into CLAUDE.md that tell the agent to check doctrine
+- **`/invest-check`** is a quick preflight you run at the start of a session
+- **`/invest-architecture`** catches drift before it gets committed
+
+The pattern is: **tell the agent once (bootstrap), remind it periodically (check), catch mistakes (architecture).**
+
+If your agent is ignoring doctrine, run `/invest-bootstrap` to re-establish the instructions, then `/invest-check` to confirm they're loaded.
+
+---
+
+## Version History
+
+| Version | What changed |
+|---------|-------------|
+| v1.0 | Initial scaffold: VECTOR.md, CLAUDE.md, ARCHITECTURE.md templates |
+| v1.1 | Added `invest-backfill` — retrofit doctrine onto existing projects |
+| v1.2 | Added `invest-doctrine` — validate doctrine completeness and consistency |
+| v1.3 | Added `invest-architecture` — audit code against declared conventions |
+| v1.4 | Added `/vector` directory structure, research schemas, install script |
+| v1.5 | Added `invest-bootstrap` and `invest-check` (active enforcement). Skill tiers (core vs extended). First-5-minutes guide. |
+
+If you installed before v1.5 and only have 3 skills, run `npx investiture init` again — it adds new skills without overwriting existing doctrine files.
+
+---
 
 ## The Metaphor
 


### PR DESCRIPTION
## Summary

Addresses feedback from a user who installed Investiture, ran `/invest-doctrine`, got a working project — but then the agent ignored the methodology entirely. Doctrine files sat in the repo unused.

- **`invest-bootstrap`** — writes Investiture instructions into CLAUDE.md so agents know to read doctrine and follow it. This is the "make it stick" skill.
- **`invest-check`** — quick read-only preflight at session start. Spot-checks 3 files against doctrine, reports status, suggests next steps.
- **Skill tiers** — core (5 skills every project needs) vs extended (21+ optional skills organized by group). Prevents the "26 skills, where do I start?" problem.
- **"First 5 minutes" guide** — literal minute-by-minute walkthrough of what happens after install.
- **"Why agents don't follow doctrine automatically"** — explains the tell-once/remind/catch pattern.
- **Version history** — v1.0 through v1.5, so users on older versions know what's current.
- **Updated getting-started.md** — two clear paths (existing vs new), troubleshooting for agents ignoring doctrine.

## Skill count

Before: 3 skills (backfill, doctrine, architecture)
After: 5 core skills (+ bootstrap, check)

## What this doesn't do

This PR does not include the 21 extended skills from #4. The docs here reference them by group so both PRs can merge in either order without conflict.

## Test plan

- [ ] Run `/invest-bootstrap` on a project with existing doctrine — verify it appends Investiture section to CLAUDE.md without destroying existing content
- [ ] Run `/invest-bootstrap` twice — verify it's idempotent (no duplicate sections)
- [ ] Run `/invest-check` on a healthy project — verify clean output
- [ ] Run `/invest-check` on a project with missing doctrine — verify it flags gaps and suggests next steps
- [ ] Verify invest.md version history matches actual release history
- [ ] Verify docs/getting-started.md paths match invest.md invocation order

🤖 Generated with [Claude Code](https://claude.com/claude-code)